### PR TITLE
Implement SSH-key upload API

### DIFF
--- a/master-portal/master-portal-common/src/main/java/org/masterportal/oauth2/servlet/MPOA4MPConfigTags.java
+++ b/master-portal/master-portal-common/src/main/java/org/masterportal/oauth2/servlet/MPOA4MPConfigTags.java
@@ -4,6 +4,8 @@ import edu.uiuc.ncsa.myproxy.oa4mp.server.OA4MPConfigTags;
 
 public interface MPOA4MPConfigTags extends OA4MPConfigTags {
 
+	// Name of table containing the SSH keys
+	public static final String SSH_KEY_STORE = "sshKeys";
 	
 	// attribute of the myproxy tag
 	public static final String MYPROXY_PASSWORD = "password";

--- a/master-portal/master-portal-common/src/main/java/org/masterportal/oauth2/servlet/MPOA4MPConfigTags.java
+++ b/master-portal/master-portal-common/src/main/java/org/masterportal/oauth2/servlet/MPOA4MPConfigTags.java
@@ -3,21 +3,24 @@ package org.masterportal.oauth2.servlet;
 import edu.uiuc.ncsa.myproxy.oa4mp.server.OA4MPConfigTags;
 
 public interface MPOA4MPConfigTags extends OA4MPConfigTags {
-
-	// Name of table containing the SSH keys
-	public static final String SSH_KEY_STORE = "sshKeys";
-	
-	// attribute of the myproxy tag
-	public static final String MYPROXY_PASSWORD = "password";
-	
-	// inner child elements of the myproxy tag
-	public static final String MYPROXY_DEFAULT_LIFETIME = "defaultLifetime";
-	public static final String MYPROXY_MAXIMUM_LIFETIME = "maximumLifetime";
-	
-	// validators
-	public static final String MYPROXY_REQ_VALIDATORS = "validators";
-	public static final String MYPROXY_REQ_VALIDATOR = "validator";
-	public static final String MYPROXY_REQ_VALIDATOR_HANDLER = "handler";
-	public static final String MYPROXY_REQ_VALIDATOR_INPUT = "input";
-	public static final String MYPROXY_REQ_VALIDATOR_INPUT_NAME = "name";
+    // the name of the ssh keys store backend
+    public static final String SSH_KEY_STORE = "sshKeys";
+    // name of the ssh keys node
+    public static final String SSH_KEYS = "sshkeys";
+    // name of max ssh keys childnode
+    public static final String MAX_SSH_KEYS = "max";
+    
+    // attribute of the myproxy tag
+    public static final String MYPROXY_PASSWORD = "password";
+    
+    // inner child elements of the myproxy tag
+    public static final String MYPROXY_DEFAULT_LIFETIME = "defaultLifetime";
+    public static final String MYPROXY_MAXIMUM_LIFETIME = "maximumLifetime";
+    
+    // validators
+    public static final String MYPROXY_REQ_VALIDATORS = "validators";
+    public static final String MYPROXY_REQ_VALIDATOR = "validator";
+    public static final String MYPROXY_REQ_VALIDATOR_HANDLER = "handler";
+    public static final String MYPROXY_REQ_VALIDATOR_INPUT = "input";
+    public static final String MYPROXY_REQ_VALIDATOR_INPUT_NAME = "name";
 }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/MPOA2SE.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/MPOA2SE.java
@@ -7,6 +7,8 @@ import java.util.List;
 import javax.inject.Provider;
 
 import org.masterportal.oauth2.server.validators.GetProxyRequestValidator;
+import org.masterportal.oauth2.server.storage.SSHKeyStore;
+import org.masterportal.oauth2.server.storage.SSHKey;
 
 import edu.uiuc.ncsa.myproxy.oa4mp.oauth2.OA2SE;
 import edu.uiuc.ncsa.myproxy.oa4mp.server.MyProxyFacadeProvider;
@@ -29,94 +31,108 @@ import edu.uiuc.ncsa.security.util.jwk.JSONWebKeys;
 
 public class MPOA2SE extends OA2SE {
 
-	public MPOA2SE(MyLoggingFacade logger,
-		       Provider<TransactionStore> tsp,
-		       Provider<ClientStore> csp,
-		       int maxAllowedNewClientRequests,
-		       long rtLifetime,
-		       Provider<ClientApprovalStore> casp,
-		       List<MyProxyFacadeProvider> mfp,
-		       MailUtilProvider mup,
-		       MessagesProvider messagesProvider,
-		       Provider<AGIssuer> agip,
-		       Provider<ATIssuer> atip,
-		       Provider<PAIssuer> paip,
-		       Provider<TokenForge> tfp,
-		       HashMap<String,
-		       String> constants,
-		       AuthorizationServletConfig ac,
-		       UsernameTransformer usernameTransformer,
-		       boolean isPingable,
-		       Provider<PermissionsStore> psp,
-		       Provider<AdminClientStore> acs,
-		       int clientSecretLength,
-		       Collection<String> scopes,
-		       ScopeHandler scopeHandler,
-		       LDAPConfiguration ldapConfiguration2,
-		       boolean isRefreshTokenEnabled,
-		       boolean twoFactorSupportEnabled,
-		       long maxClientRefreshTokenLifetime,
-		       JSONWebKeys jsonWebKeys,
-		       String myproxyPassword,
-		       long myproxyDefaultLifetime,
-		       GetProxyRequestValidator[] validators,
-		       String issuer) {
+    public MPOA2SE(MyLoggingFacade logger,
+		   Provider<TransactionStore> tsp,
+		   Provider<ClientStore> csp,
+		   Provider<SSHKeyStore> ssp,
+		   int maxAllowedNewClientRequests,
+		   long rtLifetime,
+		   Provider<ClientApprovalStore> casp,
+		   List<MyProxyFacadeProvider> mfp,
+		   MailUtilProvider mup,
+		   MessagesProvider messagesProvider,
+		   Provider<AGIssuer> agip,
+		   Provider<ATIssuer> atip,
+		   Provider<PAIssuer> paip,
+		   Provider<TokenForge> tfp,
+		   HashMap<String,
+		   String> constants,
+		   AuthorizationServletConfig ac,
+		   UsernameTransformer usernameTransformer,
+		   boolean isPingable,
+		   Provider<PermissionsStore> psp,
+		   Provider<AdminClientStore> acs,
+		   int clientSecretLength,
+		   Collection<String> scopes,
+		   ScopeHandler scopeHandler,
+		   LDAPConfiguration ldapConfiguration2,
+		   boolean isRefreshTokenEnabled,
+		   boolean twoFactorSupportEnabled,
+		   long maxClientRefreshTokenLifetime,
+		   JSONWebKeys jsonWebKeys,
+		   String myproxyPassword,
+		   long myproxyDefaultLifetime,
+		   GetProxyRequestValidator[] validators,
+		   String issuer) {
 		
-		super(logger,
-		      tsp,
-		      csp,
-		      maxAllowedNewClientRequests,
-		      rtLifetime,
-		      casp,
-		      mfp,
-		      mup,
-		      messagesProvider,
-		      agip,
-		      atip,
-		      paip,
-		      tfp,
-		      constants,
-		      ac,
-		      usernameTransformer,
-		      isPingable,
-		      psp,
-		      acs,
-		      clientSecretLength,
-		      scopes,
-		      scopeHandler,
-		      ldapConfiguration2,
-		      isRefreshTokenEnabled,
-		      twoFactorSupportEnabled,
-		      maxClientRefreshTokenLifetime,
-		      jsonWebKeys,
-		      issuer);
-		
-		this.myproxyPassword = myproxyPassword;
-		this.myproxyDefaultLifetime = myproxyDefaultLifetime;
-		
-		this.validators = validators;
-	}
+	super(logger,
+	      tsp,
+	      csp,
+	      maxAllowedNewClientRequests,
+	      rtLifetime,
+	      casp,
+	      mfp,
+	      mup,
+	      messagesProvider,
+	      agip,
+	      atip,
+	      paip,
+	      tfp,
+	      constants,
+	      ac,
+	      usernameTransformer,
+	      isPingable,
+	      psp,
+	      acs,
+	      clientSecretLength,
+	      scopes,
+	      scopeHandler,
+	      ldapConfiguration2,
+	      isRefreshTokenEnabled,
+	      twoFactorSupportEnabled,
+	      maxClientRefreshTokenLifetime,
+	      jsonWebKeys,
+	      issuer);
+	    
+	this.myproxyPassword = myproxyPassword;
+	this.myproxyDefaultLifetime = myproxyDefaultLifetime;
 	
-	protected GetProxyRequestValidator[] validators;
+	this.validators = validators;
+
+	this.ssp = ssp;
+    }
 	
-	public GetProxyRequestValidator[] getValidators() {
-		return validators;
-	}
+    protected GetProxyRequestValidator[] validators;
+    
+    public GetProxyRequestValidator[] getValidators() {
+	return validators;
+    }
 	
     protected String myproxyPassword;
     
     public void setMyproxyPassword(String myproxyPassword) {
-		this.myproxyPassword = myproxyPassword;
-	}
+	this.myproxyPassword = myproxyPassword;
+    }
     
     public String getMyproxyPassword() {
-		return myproxyPassword;
-	}
+	return myproxyPassword;
+    }
     
     long myproxyDefaultLifetime;
     
     public long getMyproxyDefaultLifetime() {
-		return myproxyDefaultLifetime;
-	}
-    
+	return myproxyDefaultLifetime;
+    }
+
+    protected Provider<SSHKeyStore> ssp;
+
+    protected SSHKeyStore<SSHKey> sshKeyStore;
+
+    public SSHKeyStore<SSHKey> getSSHKeyStore() {
+        if (sshKeyStore == null) {
+            sshKeyStore = ssp.get();
+        }
+        return sshKeyStore;
+    }
+
 }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/MPOA2SE.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/MPOA2SE.java
@@ -62,6 +62,7 @@ public class MPOA2SE extends OA2SE {
 		   JSONWebKeys jsonWebKeys,
 		   String myproxyPassword,
 		   long myproxyDefaultLifetime,
+		   int maxSSHKeys,
 		   GetProxyRequestValidator[] validators,
 		   String issuer) {
 		
@@ -100,6 +101,8 @@ public class MPOA2SE extends OA2SE {
 	this.validators = validators;
 
 	this.ssp = ssp;
+
+	this.maxSSHKeys = maxSSHKeys;
     }
 	
     protected GetProxyRequestValidator[] validators;
@@ -133,6 +136,12 @@ public class MPOA2SE extends OA2SE {
             sshKeyStore = ssp.get();
         }
         return sshKeyStore;
+    }
+
+    protected int maxSSHKeys;
+
+    public int getMaxSSHKeys()	{
+	return maxSSHKeys;
     }
 
 }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/loader/MPOA2ServerLoader.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/loader/MPOA2ServerLoader.java
@@ -105,8 +105,7 @@ public class MPOA2ServerLoader<T extends ServiceEnvironmentImpl>  extends OA2Con
     	if ( sshKeySP == null ) {
 	     sshKeySP = new MultiSSHKeyStoreProvider(cn, isDefaultStoreDisabled(), loggerProvider.get(), null, null);
 	     
-	     SSHKeyIdentifierProvider identifier = new SSHKeyIdentifierProvider();
-	     SSHKeyProvider provider = new SSHKeyProvider( identifier );
+	     SSHKeyProvider provider = new SSHKeyProvider( new SSHKeyIdentifierProvider() );
 	     SSHKeyConverter converter = new SSHKeyConverter( new SSHKeyKeys(), provider);
 
 	     sshKeySP.addListener( new SQLSSHKeyStoreProvider(cn,

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyListingServlet.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyListingServlet.java
@@ -1,0 +1,88 @@
+package edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet;
+
+import org.masterportal.oauth2.server.storage.SSHKey;
+import org.masterportal.oauth2.server.storage.SSHKeyIdentifier;
+import org.masterportal.oauth2.server.storage.sql.SQLSSHKeyStore;
+
+import edu.uiuc.ncsa.security.delegation.storage.Client;
+
+import org.masterportal.oauth2.server.MPOA2SE;
+
+//import edu.uiuc.ncsa.myproxy.oa4mp.oauth2.OA2SE;
+import edu.uiuc.ncsa.myproxy.oa4mp.server.servlet.MyProxyDelegationServlet;
+import edu.uiuc.ncsa.security.core.exceptions.InvalidTimestampException;
+import edu.uiuc.ncsa.security.delegation.server.ServiceTransaction;
+import edu.uiuc.ncsa.security.delegation.server.request.IssuerResponse;
+import edu.uiuc.ncsa.security.delegation.token.AccessToken;
+import edu.uiuc.ncsa.security.core.exceptions.GeneralException;
+import edu.uiuc.ncsa.security.oauth_2_0.OA2Client;
+import edu.uiuc.ncsa.security.oauth_2_0.OA2Errors;
+import edu.uiuc.ncsa.security.oauth_2_0.OA2GeneralError;
+
+import edu.uiuc.ncsa.security.oauth_2_0.OA2Utilities;
+//import edu.uiuc.ncsa.security.oauth_2_0.server.ScopeHandler;
+//import edu.uiuc.ncsa.security.oauth_2_0.server.UII2;
+//import edu.uiuc.ncsa.security.oauth_2_0.server.UIIRequest2;
+//import edu.uiuc.ncsa.security.oauth_2_0.server.UIIResponse2;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+
+import static edu.uiuc.ncsa.security.oauth_2_0.OA2Constants.CLIENT_SECRET;
+import static edu.uiuc.ncsa.myproxy.oa4mp.server.ServiceConstantKeys.CONSUMER_KEY;
+import org.apache.http.HttpStatus;
+
+import edu.uiuc.ncsa.security.core.util.BasicIdentifier;
+import edu.uiuc.ncsa.security.core.Identifier;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+//import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collection;
+import java.net.URI;
+
+import java.util.Base64;
+
+import java.io.Writer;
+
+import edu.uiuc.ncsa.security.core.util.MyLoggingFacade;
+
+import static edu.uiuc.ncsa.security.core.util.DateUtils.checkTimestamp;
+
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ */
+public class MPOA2SSHKeyListingServlet extends MyProxyDelegationServlet {
+    @Override
+    public ServiceTransaction verifyAndGet(IssuerResponse iResponse) throws IOException {
+	return null;
+    }
+
+    @Override
+    protected void doIt(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+	MyLoggingFacade logger = new MyLoggingFacade(getClass().getSimpleName(), false);
+
+	MPOA2SE se = (MPOA2SE)getServiceEnvironment();
+
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    throw new GeneralException("Could not get SSHKeyStore"); 
+	}
+
+	Collection<SSHKey> keys = store.values();
+   
+	Writer writer = response.getWriter();
+	for (SSHKey key : keys)    {
+	    writer.write(key.getUserName());
+	    writer.write(",");
+	    writer.write(key.getPubKey());
+	    writer.write("\n");
+	}
+	writer.flush();
+	writer.close();
+    }
+
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyListingServlet.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyListingServlet.java
@@ -1,9 +1,10 @@
-package edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet;
+package org.masterportal.oauth2.server.servlet;
 
 import org.masterportal.oauth2.server.storage.SSHKey;
 import org.masterportal.oauth2.server.storage.sql.SQLSSHKeyStore;
 import org.masterportal.oauth2.server.MPOA2SE;
 
+import edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet.OA2ExceptionHandler;
 import edu.uiuc.ncsa.myproxy.oa4mp.server.servlet.MyProxyDelegationServlet;
 import edu.uiuc.ncsa.security.delegation.server.ServiceTransaction;
 import edu.uiuc.ncsa.security.delegation.server.request.IssuerResponse;
@@ -13,18 +14,24 @@ import edu.uiuc.ncsa.security.core.exceptions.GeneralException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletException;
-import java.io.IOException;
-import java.util.Collection;
 
 import java.io.Writer;
+import java.io.IOException;
+import java.util.Collection;
 
 
 /**
  * <p>Created by Mischa Sall&eacute;<br>
+ * Simple servlet for returning the full list of public keys of all the users,
+ * to be used (e.g.) in an sshd AuthorizedKeysCommand.
+ * @see MPOA2SSHKeyServlet
  */
 public class MPOA2SSHKeyListingServlet extends MyProxyDelegationServlet {
     private MPOA2SE se;
     private MyLoggingFacade logger;
+
+    /** separator between username and public key fields */
+    private static final String SEP = " ";
 
     @Override
     public void init() throws ServletException	{
@@ -37,6 +44,10 @@ public class MPOA2SSHKeyListingServlet extends MyProxyDelegationServlet {
 	setExceptionHandler(new OA2ExceptionHandler(logger));
     }
 
+    /**
+     * Not implemented
+     * @return null
+     */
     @Override
     public ServiceTransaction verifyAndGet(IssuerResponse iResponse) throws IOException {
 	return null;
@@ -54,6 +65,11 @@ public class MPOA2SSHKeyListingServlet extends MyProxyDelegationServlet {
 	getExceptionHandler().handleException(t, request, response);
     }
 
+    /**
+     * Main method called by TomCat upon receiving either a get or post (via
+     * {@link AbstractServlet). Writes the list of stored keys and usernames,
+     * space-separated to the response.
+     */
     @Override
     protected void doIt(HttpServletRequest request, HttpServletResponse response) throws Throwable {
 	
@@ -67,7 +83,7 @@ public class MPOA2SSHKeyListingServlet extends MyProxyDelegationServlet {
 	Writer writer = response.getWriter();
 	for (SSHKey key : keys)    {
 	    writer.write(key.getUserName());
-	    writer.write(" ");
+	    writer.write(SEP);
 	    writer.write(key.getPubKey());
 	    writer.write("\n");
 	}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyListingServlet.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyListingServlet.java
@@ -1,39 +1,14 @@
 package edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet;
 
 import org.masterportal.oauth2.server.storage.SSHKey;
-import org.masterportal.oauth2.server.storage.SSHKeyIdentifier;
 import org.masterportal.oauth2.server.storage.sql.SQLSSHKeyStore;
-
-import edu.uiuc.ncsa.security.delegation.storage.Client;
-
 import org.masterportal.oauth2.server.MPOA2SE;
 
-//import edu.uiuc.ncsa.myproxy.oa4mp.oauth2.OA2SE;
 import edu.uiuc.ncsa.myproxy.oa4mp.server.servlet.MyProxyDelegationServlet;
-import edu.uiuc.ncsa.security.core.exceptions.InvalidTimestampException;
 import edu.uiuc.ncsa.security.delegation.server.ServiceTransaction;
 import edu.uiuc.ncsa.security.delegation.server.request.IssuerResponse;
-import edu.uiuc.ncsa.security.delegation.token.AccessToken;
+import edu.uiuc.ncsa.security.core.util.MyLoggingFacade;
 import edu.uiuc.ncsa.security.core.exceptions.GeneralException;
-import edu.uiuc.ncsa.security.oauth_2_0.OA2Client;
-import edu.uiuc.ncsa.security.oauth_2_0.OA2Errors;
-import edu.uiuc.ncsa.security.oauth_2_0.OA2GeneralError;
-
-import edu.uiuc.ncsa.security.oauth_2_0.OA2Utilities;
-//import edu.uiuc.ncsa.security.oauth_2_0.server.ScopeHandler;
-//import edu.uiuc.ncsa.security.oauth_2_0.server.UII2;
-//import edu.uiuc.ncsa.security.oauth_2_0.server.UIIRequest2;
-//import edu.uiuc.ncsa.security.oauth_2_0.server.UIIResponse2;
-
-import org.apache.commons.codec.digest.DigestUtils;
-
-
-import static edu.uiuc.ncsa.security.oauth_2_0.OA2Constants.CLIENT_SECRET;
-import static edu.uiuc.ncsa.myproxy.oa4mp.server.ServiceConstantKeys.CONSUMER_KEY;
-import org.apache.http.HttpStatus;
-
-import edu.uiuc.ncsa.security.core.util.BasicIdentifier;
-import edu.uiuc.ncsa.security.core.Identifier;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -42,8 +17,6 @@ import java.io.IOException;
 import java.util.Collection;
 
 import java.io.Writer;
-
-import edu.uiuc.ncsa.security.core.util.MyLoggingFacade;
 
 
 /**
@@ -60,7 +33,6 @@ public class MPOA2SSHKeyListingServlet extends MyProxyDelegationServlet {
 	setEnvironment(se);
 
 	// Create custom logger for exceptions and the like
-//	logger = new MyLoggingFacade(getClass().getSimpleName(), false);
 	logger = getMyLogger();
 	setExceptionHandler(new OA2ExceptionHandler(logger));
     }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
@@ -525,16 +525,18 @@ public class MPOA2SSHKeyServlet extends MyProxyDelegationServlet {
      */
     private String createLabel(String userName, List<SSHKey> currKeys)	{
 	if (currKeys!=null) {
-	    // Loop backwards over keys until we find matching ssh-key-[0-9]\+
-	    for (int i=currKeys.size()-1; i>=0 ; i--) {
+	    int max=0;
+	    // Loop over all keys to find highest matching ssh-key-[0-9]\+
+	    for (int i=0; i<currKeys.size(); i++) {
 		String label=currKeys.get(i).getLabel();
 		if (label.matches(LABEL_PREFIX+"[0-9]+"))    {
-		    // Found the last one, now get the suffix, add one and
-		    // create the new label
-		    int newSerial=1+Integer.parseInt(label.substring(LABEL_PREFIX.length()));
-		    return LABEL_PREFIX+Integer.toString(newSerial);
+		    int val = Integer.parseInt(label.substring(LABEL_PREFIX.length()));
+		    if (val>max)
+			max=val;
 		}
 	    }
+	    // Found the highest one (or 0): new one is one higher
+	    return LABEL_PREFIX+Integer.toString(1+max);
 	}
 
 	// No matches, will use new default

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
@@ -200,7 +200,7 @@ public class MPOA2SSHKeyServlet extends MyProxyDelegationServlet {
 
 	// do sanity check on pubkey
 	if (!isSSHPubKey(pubkey)) {
-	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Pubkey does not look like a SSH public key: "+pubkey, HttpStatus.SC_BAD_REQUEST);
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Pubkey does not look like a SSH public key", HttpStatus.SC_BAD_REQUEST);
 	}
 
 	// try to get store
@@ -210,13 +210,21 @@ public class MPOA2SSHKeyServlet extends MyProxyDelegationServlet {
 	    throw new GeneralException("Could not get SSH KeyStore"); 
 	}
 
+	// Create new SSHKey object
+	SSHKey key = new SSHKey(username, label, pubkey, description);
+
+	// Check whether the ssh pubkey already exists
+	if ( store.containsKey(key) )  {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "SSH Pubkey is already registered", HttpStatus.SC_BAD_REQUEST);
+	}
+
 	// Store the new key
 	try {
 	    // when label isn't set, create one
 	    if (label==null || label.isEmpty()) {
-		label = store.createLabel(username);
+		key.setLabel(store.createLabel(username));
 	    }
-	    store.save(new SSHKey(username, label, pubkey, description));
+	    store.save(key);
 	} catch (Exception e)	{
 	    Throwable cause = e.getCause();
 	    if (cause == null)

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
@@ -274,14 +274,17 @@ public class MPOA2SSHKeyServlet extends MyProxyDelegationServlet {
 
 	// Update values
 	if (pubkey != null)    {
+	    info("Updating pubkey for key");
 	    value.setPubKey(pubkey);
 	}
 	if (description != null)    {
+	    info("Updating description for key");
 	    value.setDescription(description);
 	}
 
 	// Update the pubkey
 	try {
+	    info("Updating the entry for "+username+", "+label);
 	    store.update(value);
 	} catch (Exception e)	{
 	    Throwable cause = e.getCause();
@@ -379,12 +382,7 @@ public class MPOA2SSHKeyServlet extends MyProxyDelegationServlet {
 	    throw new GeneralException("Could not get SSH KeyStore"); 
 	}
 
-	List<SSHKey> keys = store.getAll(userName);
-	if (keys==null) {
-	    throw new OA2GeneralError("not_found", "No key found", HttpStatus.SC_NOT_FOUND);
-	}
-    
-	return keys;
+	return store.getAll(userName);
     }
 
 

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
@@ -1,4 +1,4 @@
-package edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet;
+package org.masterportal.oauth2.server.servlet;
 
 import org.masterportal.oauth2.server.MPOA2SE;
 
@@ -41,30 +41,35 @@ import java.net.URI;
 import java.io.Writer;
 import java.io.IOException;
 import java.util.List;
+import java.util.Collections;
 import java.util.Base64;
 
 
 /**
  * <p>Created by Mischa Sall&eacute;<br>
+ * Main SSH public Key API servlet for uploading SSH pulbic keys to the Master
+ * Portal. The resulting list can be obtained via the {@link
+ * MPOA2SSHKeyListingServlet} servlet.
+ * @see MPOA2SSHKeyListingServlet
  */
 public class MPOA2SSHKeyServlet extends MyProxyDelegationServlet {
     // Valid request parameters
-    private final String ACTION_PARAMETER = "action";
-    private final String LABEL_PARAMETER = "label";
-    private final String PUBKEY_PARAMETER = "pubkey";
-    private final String DESCRIPTION_PARAMETER = "description";
+    private static final String ACTION_PARAMETER = "action";
+    private static final String LABEL_PARAMETER = "label";
+    private static final String PUBKEY_PARAMETER = "pubkey";
+    private static final String DESCRIPTION_PARAMETER = "description";
 
     // Valid actions
-    private final String ACTION_ADD	= "add";
-    private final String ACTION_UPDATE	= "update";
-    private final String ACTION_REMOVE	= "remove";
-    private final String ACTION_GET	= "get";
-    private final String ACTION_LIST	= "list";
+    private static final String ACTION_ADD	= "add";
+    private static final String ACTION_UPDATE	= "update";
+    private static final String ACTION_REMOVE	= "remove";
+    private static final String ACTION_GET	= "get";
+    private static final String ACTION_LIST	= "list";
 
     // SSH public key's first field should start with the following
-    private final String SSH_KEY_START = "ssh-";
+    private static final String SSH_KEY_START = "ssh-";
     // default labels start with prefix followed by a serial
-    private final String LABEL_PREFIX="ssh-key-";
+    private static final String LABEL_PREFIX="ssh-key-";
 
 
     private MPOA2SE se;
@@ -82,446 +87,17 @@ public class MPOA2SSHKeyServlet extends MyProxyDelegationServlet {
 	setExceptionHandler(new OA2ExceptionHandler(logger));
     }
 
+    /**
+     * Servlet does not implement/use verifyAndGet
+     */
     @Override
     public ServiceTransaction verifyAndGet(IssuerResponse iResponse) throws IOException {
 	return null;
     }
 
-    @Override
-    protected void handleException(Throwable t, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
-	// ok, if it is a strange error, print a stack if you need to.
-	// Note: getMyLogger gives logger from environment, which is configured
-	// via conf file and logs typically into mp server logs, not in
-	// /var/log/messages
-        if (logger.isDebugOn()) {
-            t.printStackTrace();
-        }
-	getExceptionHandler().handleException(t, request, response);
-    }
-
-    @Override
-    protected void doIt(HttpServletRequest request, HttpServletResponse response) throws Throwable {
-	// Get transaction for this request, based on access_token
-	ServiceTransaction transaction = getAndVerifyTransaction(request);
-
-	// Get the client_id: for ADD and DELETE this is mandatory, for the
-	// others: if present it should be valid and match the access_token
-	Client client = getClient(request);
-	if (client!=null) {
-	    if (! transaction.getClient().equals(client)) {
-		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "client_id does not match access token.", HttpStatus.SC_BAD_REQUEST);
-	    }
-	    checkClient(client);
-	}
-
-	// Get username from transaction
-	String userName=transaction.getUsername();
-
-	// Get parameters from request: they will be null if absent
-	String action = null;
-	String label = null;
-	String pubkey = null;
-	String description = null;
-	try {
-	    action = OA2Utilities.getParam(request, ACTION_PARAMETER);
-	    label = OA2Utilities.getParam(request, LABEL_PARAMETER);
-	    pubkey = OA2Utilities.getParam(request, PUBKEY_PARAMETER);
-	    description = OA2Utilities.getParam(request, DESCRIPTION_PARAMETER);
-	} catch (OA2RedirectableError e)	{
-	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, e.getDescription(), HttpStatus.SC_BAD_REQUEST);
-	}
-
-	// action must be present
-	if (action==null)	{
-	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
-				      "Missing mandatory action parameter",
-				      HttpStatus.SC_BAD_REQUEST);
-	}
-	
-	switch (action) {
-	    case ACTION_ADD :
-		// For adding client is mandatory
-		if (client==null)   {
-		    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
-					      "Missing client for action "+action,
-					      HttpStatus.SC_BAD_REQUEST);
-		}
-		addKey(userName, label, pubkey, description);
-		break;
-	    case ACTION_UPDATE :
-		// For adding client is mandatory
-		if (client==null)   {
-		    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
-					      "Missing client for action "+action,
-					      HttpStatus.SC_BAD_REQUEST);
-		}
-		updateKey(userName, label, pubkey, description);
-		break;
-	    case ACTION_REMOVE :
-		removeKey(userName, label);
-		break;
-	    case ACTION_GET :
-		SSHKey key = getKey(userName, label);
-		writeKeys(response, java.util.Collections.singletonList(key));
-		break;
-	    case ACTION_LIST :
-		writeKeys(response, getKeys(userName));
-		break;
-	    default:
-		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
-					  "Invalid action specified: "+action,
-					  HttpStatus.SC_BAD_REQUEST);
-	}
-    }
-
     /**
-     * adds entry for given user, label
-     */
-    private void addKey(String username, String label, String pubkey, String description) throws Throwable {
-	// username and pubkey may not be empty
-	if (username==null || username.isEmpty())   {
-	    logger.error("Username is null or empty");
-	    throw new GeneralException("Cannot get username");
-	}
-	if (pubkey==null || pubkey.isEmpty()) {
-	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory pubkey", HttpStatus.SC_BAD_REQUEST);
-	}
-
-	// do sanity check on pubkey
-	if (!isSSHPubKey(pubkey)) {
-	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Pubkey does not look like a SSH public key", HttpStatus.SC_BAD_REQUEST);
-	}
-
-	// try to get store
-	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
-	if ( store == null) {
-	    logger.error("Cannot get SSHKeyStore");
-	    throw new GeneralException("Could not get SSH KeyStore"); 
-	}
-
-	// Create new SSHKey object
-	SSHKey key = new SSHKey(username, label, pubkey, description);
-
-	// Check whether the ssh pubkey already exists
-	if ( store.containsKey(key) )  {
-	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "SSH Pubkey is already registered", HttpStatus.SC_BAD_REQUEST);
-	}
-
-	// Get existing keys: we need them either for counting or for creating
-	// the next label
-	List<SSHKey> currKeys = store.getAll(username);
-
-	// Check we don't have too many
-	int maxSSHKeys = se.getMaxSSHKeys();
-	if (maxSSHKeys > 0 && currKeys.size() >= maxSSHKeys)    {
-	    logger.info("Maximum number of keys reached for user "+username);
-	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Maximum number of keys >= "+maxSSHKeys+", cannot add more", HttpStatus.SC_BAD_REQUEST);
-	}
-
-	// when label isn't set, create one
-	if (label==null || label.isEmpty()) {
-	    key.setLabel(createLabel(username, currKeys));
-	}
-
-	// Now save the new key
-	try {
-	    store.register(key);
-	} catch (Exception e)	{
-	    Throwable cause = e.getCause();
-	    if (cause == null)
-		logger.error("Cannot register key: "+e.getMessage());
-	    else
-		logger.error("Cannot register key: "+e.getMessage() + " (" + cause.getMessage() + ")");
-	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot add entry", HttpStatus.SC_INTERNAL_SERVER_ERROR);
-	}
-    }
-
-    /**
-     * update entry for given user, label
-     */
-    private void updateKey(String username, String label, String pubkey, String description) throws Throwable {
-	// username and label may not be empty
-	if (username==null || username.isEmpty())   {
-	    logger.error("Username is null or empty");
-	    throw new GeneralException("Cannot get username");
-	}
-	if (label==null || label.isEmpty()) {
-	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory label", HttpStatus.SC_BAD_REQUEST);
-	}
-
-	// if we specified a pubkey, it must be non-empty and valid
-	if (pubkey!=null)	{
-	    if (pubkey.isEmpty())	{
-		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "SSH public key may not be empty", HttpStatus.SC_BAD_REQUEST);
-	    }
-	    if (!isSSHPubKey(pubkey)) {
-		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "key does not look like a SSH public key", HttpStatus.SC_BAD_REQUEST);
-	    }
-	}
-
-	// try to get store
-	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
-	if ( store == null) {
-	    logger.error("Cannot get SSHKeyStore");
-	    throw new GeneralException("Could not get SSH KeyStore"); 
-	}
-    
-	// Get existing pubkey
-	SSHKey value = store.get(new SSHKey(username, label));
-	if (value==null) {
-	    throw new OA2GeneralError("not_found", "No key to update found", HttpStatus.SC_NOT_FOUND);
-	}
-
-	// Update values
-	if (pubkey != null)    {
-	    info("Updating pubkey for key");
-	    value.setPubKey(pubkey);
-	}
-	if (description != null)    {
-	    info("Updating description for key");
-	    value.setDescription(description);
-	}
-
-	// Update the pubkey
-	try {
-	    info("Updating the entry for "+username+", "+label);
-	    store.update(value);
-	} catch (Exception e)	{
-	    Throwable cause = e.getCause();
-	    if (cause == null)
-		logger.error("Cannot update key: "+e.getMessage());
-	    else
-		logger.error("Cannot update key: "+e.getMessage() + " (" + cause.getMessage() + ")");
-	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot update entry", HttpStatus.SC_INTERNAL_SERVER_ERROR);
-	}
-    }
-
-    /**
-     * removes entry for given username and label
-     */
-    private void removeKey(String userName, String label) throws Throwable {
-	// username and label may not be empty
-	if (userName==null || userName.isEmpty())   {
-	    logger.error("Username is null or empty");
-	    throw new GeneralException("Cannot get username");
-	}
-	if (label==null || label.isEmpty()) {
-	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory label", HttpStatus.SC_BAD_REQUEST);
-	}
-
-	// try to get store
-	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
-	if ( store == null) {
-	    logger.error("Cannot get SSHKeyStore");
-	    throw new GeneralException("Could not get SSHKeyStore"); 
-	}
-
-	SSHKey key = null;
-	try {
-	    key = store.remove(new SSHKey(userName, label));
-	} catch (Exception e)	{
-	    Throwable cause = e.getCause();
-	    if (cause == null)
-		logger.error("Cannot remove key: "+e.getMessage());
-	    else
-		logger.error("Cannot remove key: "+e.getMessage() + " (" + cause.getMessage() + ")");
-	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot remove key", HttpStatus.SC_INTERNAL_SERVER_ERROR);
-	}
-	if (key==null) {
-	    throw new OA2GeneralError("not_found", "No key found", HttpStatus.SC_NOT_FOUND);
-	}
-    }
-
-    /**
-     * retrieves entry for given username, label
-     */
-    private SSHKey getKey(String username, String label) throws Throwable {
-	// username and label may not be empty
-	if (username==null || username.isEmpty() || label==null || label.isEmpty()) {
-	    logger.error("Either username or label is empty");
-	    throw new GeneralException("Need username and label for getting key");
-	}
-
-	// try to get store
-	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
-	if ( store == null) {
-	    throw new GeneralException("Could not get SSH KeyStore"); 
-	}
-
-	SSHKey key = null;
-	try {
-	    key = store.get(new SSHKey(username, label));
-	} catch (Exception e)	{
-	    Throwable cause = e.getCause();
-	    if (cause == null)
-		logger.error("Cannot get key: "+e.getMessage());
-	    else
-		logger.error("Cannot get key: "+e.getMessage() + " (" + cause.getMessage() + ")");
-	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot get key", HttpStatus.SC_INTERNAL_SERVER_ERROR);
-	}
-	if (key==null) {
-	    throw new OA2GeneralError("not_found", "No key found", HttpStatus.SC_NOT_FOUND);
-	}
-    
-	return key;
-    }
-
-    /**
-     * lists all entries for given username
-     */
-    private List<SSHKey> getKeys(String userName) throws Throwable  {
-	// userName may not be empty
-	if (userName==null || userName.isEmpty()) {
-	    logger.error("Username is empty");
-	    throw new GeneralException("Cannot get username");
-	}
-
-	// try to get store
-	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
-	if ( store == null) {
-	    throw new GeneralException("Could not get SSH KeyStore"); 
-	}
-
-	return store.getAll(userName);
-    }
-
-
-    /**
-     * Returns new unique label for username, based on existing set of keys
-     */
-    public String createLabel(String userName, List<SSHKey> currKeys)	{
-	if (currKeys!=null) {
-	    // Loop backwards over keys until we find matching ssh-key-[0-9]\+
-	    for (int i=currKeys.size()-1; i>=0 ; i--) {
-		String label=currKeys.get(i).getLabel();
-		if (label.matches(LABEL_PREFIX+"[0-9]+"))    {
-		    // Found the last one, now get the suffix, add one and
-		    // create the new label
-		    int newSerial=1+Integer.parseInt(label.substring(LABEL_PREFIX.length()));
-		    return LABEL_PREFIX+Integer.toString(newSerial);
-		}
-	    }
-	}
-
-	// No matches, will use new default
-	return LABEL_PREFIX+"1";
-    }
-
-
-    /**
-     * Writes JSON-formatted array of given set of keys to the response
-     */
-    private void writeKeys(HttpServletResponse response, List<SSHKey> keys)    {
-	JSONObject json = new JSONObject();
-	for (SSHKey key : keys)	{
-	    JSONObject jsonKey = new JSONObject();
-	    jsonKey.put("label", key.getLabel());
-	    jsonKey.put("username", key.getUserName());
-	    jsonKey.put("pub_key", key.getPubKey());
-	    if (key.getDescription() != null)
-		jsonKey.put("description", key.getDescription());
-	    json.accumulate("ssh_keys", jsonKey);
-	}
-
-	String out = JSONUtils.valueToString(json, 1, 0);
-	response.setHeader("Content-Type", "application/json;charset=UTF-8");
-	try {
-	    Writer writer = response.getWriter();
-	    writer.write(out);
-	    writer.append('\n');
-	    writer.close();
-	    writer.flush();
-	} catch(IOException e)	{
-	    logger.error("Error: Cannot write keys: "+e.getMessage());
-	    throw new GeneralException("Cannot write keys");
-	}
-    }
-
-    /**
-     * Does a basic sanity check on String key, whether it looks like a SSH
-     * public key
-     */
-    private boolean isSSHPubKey(String key) {
-	int firstSpace=key.indexOf(' ');
-	if (firstSpace<0)   {
-	    logger.warn("Uploaded key does not contain a space");
-	    return false;
-	}
-
-	// Get type part: must start with ssh-
-	String type=key.substring(0, firstSpace);
-	if (! type.substring(0,4).equals(SSH_KEY_START))   {
-	    logger.warn("Uploaded key does not start with \""+SSH_KEY_START+"\"");
-	    return false;
-	}
-
-	// Get encoded part
-	int secondSpace=key.indexOf(' ', firstSpace+1);
-	String encoded;
-	if (secondSpace<0)  {
-	    encoded=key.substring(firstSpace+1);
-	} else	{
-	    encoded=key.substring(firstSpace+1,secondSpace);
-	}
-	try {
-	    byte[] decoded=Base64.getDecoder().decode(encoded);
-	} catch(IllegalArgumentException e) {
-	    logger.warn("Uploaded key does not contain base64-encoded part");
-	    return false;
-	}
-	return true;
-    }
-
-
-    /**
-     * Get access token from request, copy and paste from userinfo endpoint
-     */
-    private ServiceTransaction getAndVerifyTransaction(HttpServletRequest request) {
-	// Get access token: either bearer token or request parameter
-        AccessToken at = null;
-        List<String> authHeaders = getAuthHeader(request, "Bearer");
-
-        if(authHeaders.isEmpty()){
-            // it's not in a header, but was sent as a standard parameter.
-            at = se.getTokenForge().getAccessToken(request);
-        }else {
-            // only the very first one is taken. Don't try to snoop for them.
-            at = se.getTokenForge().getAccessToken(authHeaders.get(0));
-        }
-        if (at == null) {
-            // the bearer token should be sent in the authorization header.
-            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "no access token was sent.", HttpStatus.SC_BAD_REQUEST);
-        }
-
-	// Is it still valid
-	try {
-            checkTimestamp(at.getToken());
-        }catch(InvalidTimestampException itx){
-            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "token expired.", HttpStatus.SC_BAD_REQUEST);
-        }catch(NumberFormatException nfx)   {
-            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "invalid access token.", HttpStatus.SC_BAD_REQUEST);
-	}
-
-	// Now get the corresponding transaction and verify it's ok
-        ServiceTransaction transaction = null;
-	try {
-	    transaction = (ServiceTransaction) getTransactionStore().get(at);
-	} catch (Exception e)	{
-            logger.error("Error: Cannot get transaction for access_token: "+e.getMessage());
-            throw new GeneralException("Cannot get transaction for access_token");
-	}
-        if (transaction == null) {
-            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "no transaction for the access token was found.", HttpStatus.SC_BAD_REQUEST);
-        }
-        if (!transaction.isAccessTokenValid()) {
-            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "invalid access token.", HttpStatus.SC_BAD_REQUEST);
-        }
-
-        return transaction;
-    }
-
-    /**
-     * Copy and paste from OA2CertServlet, except we allow here an absent client
+     * Copy and paste from {@link OA2CertServlet}, except we allow here an
+     * absent client.
      */
     @Override
     public Client getClient(HttpServletRequest req) {
@@ -582,4 +158,453 @@ public class MPOA2SSHKeyServlet extends MyProxyDelegationServlet {
         }
         return client;
     }
+
+    @Override
+    protected void handleException(Throwable t, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+	// ok, if it is a strange error, print a stack if you need to.
+	// Note: getMyLogger gives logger from environment, which is configured
+	// via conf file and logs typically into mp server logs, not in
+	// /var/log/messages
+        if (logger.isDebugOn()) {
+            t.printStackTrace();
+        }
+	getExceptionHandler().handleException(t, request, response);
+    }
+
+    /**
+     * main method doing all the handling of the API requests
+     */
+    @Override
+    protected void doIt(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+	// Get transaction for this request, based on access_token
+	ServiceTransaction transaction = getAndVerifyTransaction(request);
+
+	// Get the client_id: for ADD and DELETE this is mandatory, for the
+	// others: if present it should be valid and match the access_token
+	Client client = getClient(request);
+	if (client!=null) {
+	    if (! transaction.getClient().equals(client)) {
+		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "client_id does not match access token.", HttpStatus.SC_BAD_REQUEST);
+	    }
+	    checkClient(client);
+	}
+
+	// Get username from transaction
+	String userName=transaction.getUsername();
+
+	// Get parameters from request: they will be null if absent
+	String action = null;
+	String label = null;
+	String pubKey = null;
+	String description = null;
+	try {
+	    action = OA2Utilities.getParam(request, ACTION_PARAMETER);
+	    label = OA2Utilities.getParam(request, LABEL_PARAMETER);
+	    pubKey = OA2Utilities.getParam(request, PUBKEY_PARAMETER);
+	    description = OA2Utilities.getParam(request, DESCRIPTION_PARAMETER);
+	} catch (OA2RedirectableError e)	{
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, e.getDescription(), HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// action must be present
+	if (action==null)	{
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+				      "Missing mandatory action parameter",
+				      HttpStatus.SC_BAD_REQUEST);
+	}
+	
+	switch (action) {
+	    case ACTION_ADD :
+		// For adding client is mandatory
+		if (client==null)   {
+		    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+					      "Missing client for action "+action,
+					      HttpStatus.SC_BAD_REQUEST);
+		}
+		addKey(userName, label, pubKey, description);
+		break;
+	    case ACTION_UPDATE :
+		// For adding client is mandatory
+		if (client==null)   {
+		    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+					      "Missing client for action "+action,
+					      HttpStatus.SC_BAD_REQUEST);
+		}
+		updateKey(userName, label, pubKey, description);
+		break;
+	    case ACTION_REMOVE :
+		removeKey(userName, label);
+		break;
+	    case ACTION_GET :
+		SSHKey key = getKey(userName, label);
+		writeKeys(response, Collections.singletonList(key));
+		break;
+	    case ACTION_LIST :
+		writeKeys(response, getKeys(userName));
+		break;
+	    default:
+		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+					  "Invalid action specified: "+action,
+					  HttpStatus.SC_BAD_REQUEST);
+	}
+    }
+
+    /************************************************************************
+     * API Action methods
+     ************************************************************************/
+
+    /**
+     * Adds new key for given userName, label, pubKey and description.
+     */
+    private void addKey(String userName, String label, String pubKey, String description) throws Throwable {
+	// userName and pubKey may not be empty, userName is indirect, via the
+	// access_token
+	if (userName==null || userName.isEmpty())   {
+	    logger.error("Username is null or empty");
+	    throw new GeneralException("Cannot get username");
+	}
+	if (pubKey==null || pubKey.isEmpty()) {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory pubkey", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// do (basic) sanity check on pubKey
+	if (!isSSHPubKey(pubKey)) {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Pubkey does not look like a SSH public key", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    logger.error("Cannot get SSHKeyStore");
+	    throw new GeneralException("Could not get SSH KeyStore"); 
+	}
+
+	// Create new SSHKey object
+	SSHKey key = new SSHKey(userName, label, pubKey, description);
+
+	// Check whether the ssh pubKey already occurs: must be globally unique
+	if ( store.containsKey(key) )  {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "SSH Pubkey is already registered", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// Get existing keys: we need them either for counting or for creating
+	// the next label
+	List<SSHKey> currKeys = store.getAll(userName);
+
+	// Check we don't have too many
+	int maxSSHKeys = se.getMaxSSHKeys();
+	if (maxSSHKeys > 0 && currKeys.size() >= maxSSHKeys)    {
+	    logger.info("Maximum number of keys reached for user "+userName);
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Maximum number of keys >= "+maxSSHKeys+", cannot add more", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// when label isn't set, create one
+	if (label==null || label.isEmpty()) {
+	    key.setLabel(createLabel(userName, currKeys));
+	}
+
+	// Now save the new key
+	try {
+	    store.register(key);
+	} catch (Exception e)	{
+	    Throwable cause = e.getCause();
+	    if (cause == null)
+		logger.error("Cannot register key: "+e.getMessage());
+	    else
+		logger.error("Cannot register key: "+e.getMessage() + " (" + cause.getMessage() + ")");
+	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot add entry", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+	}
+    }
+
+    /**
+     * Update entry (pubKey and/or description) for given user, label.
+     */
+    private void updateKey(String userName, String label, String pubKey, String description) throws Throwable {
+	// userName and label may not be empty
+	if (userName==null || userName.isEmpty())   {
+	    logger.error("Username is null or empty");
+	    throw new GeneralException("Cannot get username");
+	}
+	if (label==null || label.isEmpty()) {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory label", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// if we specified a pubkey, it must be non-empty and valid
+	if (pubKey!=null)	{
+	    if (pubKey.isEmpty())	{
+		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "SSH public key may not be empty", HttpStatus.SC_BAD_REQUEST);
+	    }
+	    if (!isSSHPubKey(pubKey)) {
+		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "key does not look like a SSH public key", HttpStatus.SC_BAD_REQUEST);
+	    }
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    logger.error("Cannot get SSHKeyStore");
+	    throw new GeneralException("Could not get SSH KeyStore"); 
+	}
+    
+	// Get existing pubkey
+	SSHKey value = store.get(new SSHKey(userName, label));
+	if (value==null) {
+	    throw new OA2GeneralError("not_found", "No key to update found", HttpStatus.SC_NOT_FOUND);
+	}
+
+	// Update values
+	if (pubKey != null)    {
+	    info("Updating pubkey for key");
+	    value.setPubKey(pubKey);
+	}
+	if (description != null)    {
+	    info("Updating description for key");
+	    value.setDescription(description);
+	}
+
+	// Update the value in the store
+	try {
+	    info("Updating the entry for "+userName+", "+label);
+	    store.update(value);
+	} catch (Exception e)	{
+	    Throwable cause = e.getCause();
+	    if (cause == null)
+		logger.error("Cannot update key: "+e.getMessage());
+	    else
+		logger.error("Cannot update key: "+e.getMessage() + " (" + cause.getMessage() + ")");
+	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot update entry", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+	}
+    }
+
+    /**
+     * Removes entry for given userName and label
+     */
+    private void removeKey(String userName, String label) throws Throwable {
+	// userName and label may not be empty
+	if (userName==null || userName.isEmpty())   {
+	    logger.error("Username is null or empty");
+	    throw new GeneralException("Cannot get username");
+	}
+	if (label==null || label.isEmpty()) {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory label", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    logger.error("Cannot get SSHKeyStore");
+	    throw new GeneralException("Could not get SSHKeyStore"); 
+	}
+
+	SSHKey key = null;
+	try {
+	    key = store.remove(new SSHKey(userName, label));
+	} catch (Exception e)	{
+	    Throwable cause = e.getCause();
+	    if (cause == null)
+		logger.error("Cannot remove key: "+e.getMessage());
+	    else
+		logger.error("Cannot remove key: "+e.getMessage() + " (" + cause.getMessage() + ")");
+	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot remove key", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+	}
+	if (key==null) {
+	    throw new OA2GeneralError("not_found", "No key found", HttpStatus.SC_NOT_FOUND);
+	}
+    }
+
+    /**
+     * Retrieves entry for given userName, label
+     */
+    private SSHKey getKey(String userName, String label) throws Throwable {
+	// userName and label may not be empty
+	if (userName==null || userName.isEmpty())   {
+	    logger.error("Username is null or empty");
+	    throw new GeneralException("Cannot get username");
+	}
+	if (label==null || label.isEmpty()) {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory label", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    throw new GeneralException("Could not get SSH KeyStore"); 
+	}
+
+	SSHKey key = null;
+	try {
+	    key = store.get(new SSHKey(userName, label));
+	} catch (Exception e)	{
+	    Throwable cause = e.getCause();
+	    if (cause == null)
+		logger.error("Cannot get key: "+e.getMessage());
+	    else
+		logger.error("Cannot get key: "+e.getMessage() + " (" + cause.getMessage() + ")");
+	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot get key", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+	}
+	if (key==null) {
+	    throw new OA2GeneralError("not_found", "No key found", HttpStatus.SC_NOT_FOUND);
+	}
+    
+	return key;
+    }
+
+    /**
+     * lists all entries for given userName
+     */
+    private List<SSHKey> getKeys(String userName) throws Throwable  {
+	// userName may not be empty
+	if (userName==null || userName.isEmpty()) {
+	    logger.error("Username is empty");
+	    throw new GeneralException("Cannot get username");
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    throw new GeneralException("Could not get SSH KeyStore"); 
+	}
+
+	return store.getAll(userName);
+    }
+
+    /************************************************************************
+     * Helper methods
+     ************************************************************************/
+
+    /**
+     * Get access token from request, copy and paste from userinfo endpoint
+     * {@link UserInfoServlet#doIt}
+     */
+    private ServiceTransaction getAndVerifyTransaction(HttpServletRequest request) {
+	// Get access token: either bearer token or request parameter
+        AccessToken at = null;
+        List<String> authHeaders = getAuthHeader(request, "Bearer");
+
+        if(authHeaders.isEmpty()){
+            // it's not in a header, but was sent as a standard parameter.
+            at = se.getTokenForge().getAccessToken(request);
+        }else {
+            // only the very first one is taken. Don't try to snoop for them.
+            at = se.getTokenForge().getAccessToken(authHeaders.get(0));
+        }
+        if (at == null) {
+            // the bearer token should be sent in the authorization header.
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "no access token was sent.", HttpStatus.SC_BAD_REQUEST);
+        }
+
+	// Is it still valid
+	try {
+            checkTimestamp(at.getToken());
+        }catch(InvalidTimestampException itx){
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "token expired.", HttpStatus.SC_BAD_REQUEST);
+        }catch(NumberFormatException nfx)   {
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "invalid access token.", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// Now get the corresponding transaction and verify it's ok
+        ServiceTransaction transaction = null;
+	try {
+	    transaction = (ServiceTransaction) getTransactionStore().get(at);
+	} catch (Exception e)	{
+            logger.error("Error: Cannot get transaction for access_token: "+e.getMessage());
+            throw new GeneralException("Cannot get transaction for access_token");
+	}
+        if (transaction == null) {
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "no transaction for the access token was found.", HttpStatus.SC_BAD_REQUEST);
+        }
+        if (!transaction.isAccessTokenValid()) {
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "invalid access token.", HttpStatus.SC_BAD_REQUEST);
+        }
+
+        return transaction;
+    }
+
+    /**
+     * Returns new unique label for userName, based on existing set of keys
+     */
+    private String createLabel(String userName, List<SSHKey> currKeys)	{
+	if (currKeys!=null) {
+	    // Loop backwards over keys until we find matching ssh-key-[0-9]\+
+	    for (int i=currKeys.size()-1; i>=0 ; i--) {
+		String label=currKeys.get(i).getLabel();
+		if (label.matches(LABEL_PREFIX+"[0-9]+"))    {
+		    // Found the last one, now get the suffix, add one and
+		    // create the new label
+		    int newSerial=1+Integer.parseInt(label.substring(LABEL_PREFIX.length()));
+		    return LABEL_PREFIX+Integer.toString(newSerial);
+		}
+	    }
+	}
+
+	// No matches, will use new default
+	return LABEL_PREFIX+"1";
+    }
+
+
+    /**
+     * Writes JSON-formatted array of given List of keys to the response.
+     */
+    private void writeKeys(HttpServletResponse response, List<SSHKey> keys)    {
+	JSONObject json = new JSONObject();
+	for (SSHKey key : keys)	{
+	    JSONObject jsonKey = new JSONObject();
+	    jsonKey.put("label", key.getLabel());
+	    jsonKey.put("username", key.getUserName());
+	    jsonKey.put("pub_key", key.getPubKey());
+	    if (key.getDescription() != null)
+		jsonKey.put("description", key.getDescription());
+	    json.accumulate("ssh_keys", jsonKey);
+	}
+
+	String out = JSONUtils.valueToString(json, 1, 0);
+	response.setHeader("Content-Type", "application/json;charset=UTF-8");
+	try {
+	    Writer writer = response.getWriter();
+	    writer.write(out);
+	    writer.append('\n');
+	    writer.close();
+	    writer.flush();
+	} catch(IOException e)	{
+	    logger.error("Error: Cannot write keys: "+e.getMessage());
+	    throw new GeneralException("Cannot write keys");
+	}
+    }
+
+    /**
+     * Does a basic sanity check on String key, whether it looks like an SSH
+     * public key.
+     */
+    private boolean isSSHPubKey(String key) {
+	int firstSpace=key.indexOf(' ');
+	if (firstSpace<0)   {
+	    logger.warn("Uploaded key does not contain a space");
+	    return false;
+	}
+
+	// Get type part: must start with ssh-
+	String type=key.substring(0, firstSpace);
+	if (! type.substring(0,4).equals(SSH_KEY_START))   {
+	    logger.warn("Uploaded key does not start with \""+SSH_KEY_START+"\"");
+	    return false;
+	}
+
+	// Get encoded part
+	int secondSpace=key.indexOf(' ', firstSpace+1);
+	String encoded;
+	if (secondSpace<0)  {
+	    encoded=key.substring(firstSpace+1);
+	} else	{
+	    encoded=key.substring(firstSpace+1,secondSpace);
+	}
+	try {
+	    byte[] decoded=Base64.getDecoder().decode(encoded);
+	} catch(IllegalArgumentException e) {
+	    logger.warn("Uploaded key does not contain base64-encoded part");
+	    return false;
+	}
+	return true;
+    }
+
+
 }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/servlet/MPOA2SSHKeyServlet.java
@@ -1,0 +1,551 @@
+package edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet;
+
+import org.masterportal.oauth2.server.storage.SSHKey;
+import org.masterportal.oauth2.server.storage.SSHKeyIdentifier;
+import org.masterportal.oauth2.server.storage.sql.SQLSSHKeyStore;
+
+import edu.uiuc.ncsa.security.delegation.storage.Client;
+
+import org.masterportal.oauth2.server.MPOA2SE;
+
+//import edu.uiuc.ncsa.myproxy.oa4mp.oauth2.OA2SE;
+import edu.uiuc.ncsa.myproxy.oa4mp.server.servlet.MyProxyDelegationServlet;
+import edu.uiuc.ncsa.security.core.exceptions.InvalidTimestampException;
+import edu.uiuc.ncsa.security.delegation.server.ServiceTransaction;
+import edu.uiuc.ncsa.security.delegation.server.request.IssuerResponse;
+import edu.uiuc.ncsa.security.delegation.token.AccessToken;
+import edu.uiuc.ncsa.security.core.exceptions.GeneralException;
+import edu.uiuc.ncsa.security.oauth_2_0.OA2Client;
+import edu.uiuc.ncsa.security.oauth_2_0.OA2Errors;
+import edu.uiuc.ncsa.security.oauth_2_0.OA2GeneralError;
+import edu.uiuc.ncsa.security.oauth_2_0.OA2RedirectableError;
+
+import edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet.OA2ExceptionHandler;
+
+import edu.uiuc.ncsa.security.oauth_2_0.OA2Utilities;
+//import edu.uiuc.ncsa.security.oauth_2_0.server.ScopeHandler;
+//import edu.uiuc.ncsa.security.oauth_2_0.server.UII2;
+//import edu.uiuc.ncsa.security.oauth_2_0.server.UIIRequest2;
+//import edu.uiuc.ncsa.security.oauth_2_0.server.UIIResponse2;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+
+import static edu.uiuc.ncsa.security.oauth_2_0.OA2Constants.CLIENT_SECRET;
+import static edu.uiuc.ncsa.myproxy.oa4mp.server.ServiceConstantKeys.CONSUMER_KEY;
+import org.apache.http.HttpStatus;
+
+import edu.uiuc.ncsa.security.core.util.BasicIdentifier;
+import edu.uiuc.ncsa.security.core.Identifier;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+//import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collection;
+import java.net.URI;
+
+import java.util.Base64;
+
+import java.io.Writer;
+
+import edu.uiuc.ncsa.security.core.util.MyLoggingFacade;
+
+import static edu.uiuc.ncsa.security.core.util.DateUtils.checkTimestamp;
+
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ */
+public class MPOA2SSHKeyServlet extends MyProxyDelegationServlet {
+    private final String ACTION_PARAMETER = "action";
+    private final String LABEL_PARAMETER = "label";
+    private final String PUBKEY_PARAMETER = "pubkey";
+    private final String DESCRIPTION_PARAMETER = "description";
+
+    private final String ACTION_ADD	= "add";
+    private final String ACTION_UPDATE	= "update";
+    private final String ACTION_REMOVE	= "remove";
+    private final String ACTION_GET	= "get";
+    private final String ACTION_LIST	= "list";
+
+    private final String SSH_KEY_START = "ssh-";
+
+    private MPOA2SE se;
+    private MyLoggingFacade logger;
+
+    private boolean initDone = false;
+
+    @Override
+    public void init() throws ServletException	{
+	super.init();
+	se = (MPOA2SE)getServiceEnvironment();
+	setEnvironment(se);
+
+	// Create custom logger for exceptions and the like
+//	logger = new MyLoggingFacade(getClass().getSimpleName(), false);
+	logger = getMyLogger();
+	setExceptionHandler(new OA2ExceptionHandler(logger));
+    }
+
+    @Override
+    public ServiceTransaction verifyAndGet(IssuerResponse iResponse) throws IOException {
+	return null;
+    }
+
+    @Override
+    protected void handleException(Throwable t, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+	// ok, if it is a strange error, print a stack if you need to.
+	// Note: getMyLogger gives logger from environment, which is configured
+	// via conf file and logs typically into mp server logs, not in
+	// /var/log/messages
+        if (logger.isDebugOn()) {
+            t.printStackTrace();
+        }
+	if (t.getMessage() != null) {
+	    logger.info("Handling exception for: "+t.getMessage());
+	}
+	getExceptionHandler().handleException(t, request, response);
+    }
+
+    @Override
+    protected void doIt(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+	// Get transaction for this request, based on access_token
+	ServiceTransaction transaction = getAndVerifyTransaction(request);
+
+	// Get the client_id: for PUT this is mandatory, for the others: if
+	// present it should be valid and match the access_token
+	Client client = getClient(request);
+	if (client!=null) {
+	    if (! transaction.getClient().equals(client)) {
+		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "client_id does not match access token.", HttpStatus.SC_BAD_REQUEST);
+	    }
+	    checkClient(client);
+	}
+
+	// Get username from transaction
+	String userName=transaction.getUsername();
+
+	// Get parameters from request: they will be null if absent
+	String action = null;
+	String label = null;
+	String pubkey = null;
+	String description = null;
+	try {
+	    action = OA2Utilities.getParam(request, ACTION_PARAMETER);
+	    label = OA2Utilities.getParam(request, LABEL_PARAMETER);
+	    pubkey = OA2Utilities.getParam(request, PUBKEY_PARAMETER);
+	    description = OA2Utilities.getParam(request, DESCRIPTION_PARAMETER);
+	} catch (OA2RedirectableError e)	{
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, e.getDescription(), HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// action must be present
+	if (action==null)	{
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+				      "Missing mandatory action parameter",
+				      HttpStatus.SC_BAD_REQUEST);
+	}
+	
+	switch (action) {
+	    case ACTION_ADD :
+		// For adding client is mandatory
+		if (client==null)   {
+		    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+					      "Missing client for action "+action,
+					      HttpStatus.SC_BAD_REQUEST);
+		}
+		addKey(userName, label, pubkey, description);
+		break;
+	    case ACTION_UPDATE :
+		// For adding client is mandatory
+		if (client==null)   {
+		    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+					      "Missing client for action "+action,
+					      HttpStatus.SC_BAD_REQUEST);
+		}
+		updateKey(userName, label, pubkey, description);
+		break;
+	    case ACTION_REMOVE :
+		removeKey(userName, label);
+		break;
+	    case ACTION_GET :
+		SSHKey key = getKey(userName, label);
+		writeKeys(response, java.util.Collections.singletonList(key));
+		break;
+	    case ACTION_LIST :
+		writeKeys(response, getKeys(userName));
+		break;
+	    default:
+		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+					  "Invalid action specified: "+action,
+					  HttpStatus.SC_BAD_REQUEST);
+	}
+    }
+
+    /**
+     * adds entry for given user, label
+     */
+    private void addKey(String username, String label, String pubkey, String description) throws Throwable {
+	// username and pubkey may not be empty
+	if (username==null || username.isEmpty())   {
+	    logger.error("Username is null or empty");
+	    throw new GeneralException("Cannot get username");
+	}
+	if (pubkey==null || pubkey.isEmpty()) {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory pubkey", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// do sanity check on pubkey
+	if (!isSSHPubKey(pubkey)) {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Pubkey does not look like a SSH public key: "+pubkey, HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    logger.error("Cannot get SSHKeyStore");
+	    throw new GeneralException("Could not get SSH KeyStore"); 
+	}
+
+	// Store the new key
+	try {
+	    // when label isn't set, create one
+	    if (label==null || label.isEmpty()) {
+		label = store.createLabel(username);
+	    }
+	    store.save(new SSHKey(username, label, pubkey, description));
+	} catch (Exception e)	{
+	    Throwable cause = e.getCause();
+	    if (cause == null)
+		logger.error("Cannot save key: "+e.getMessage());
+	    else
+		logger.error("Cannot save key: "+e.getMessage() + " (" + cause.getMessage() + ")");
+	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot add entry", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+	}
+    }
+
+    /**
+     * update entry for given user, label
+     */
+    private void updateKey(String username, String label, String pubkey, String description) throws Throwable {
+	// username and label may not be empty
+	if (username==null || username.isEmpty())   {
+	    logger.error("Username is null or empty");
+	    throw new GeneralException("Cannot get username");
+	}
+	if (label==null || label.isEmpty()) {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory label", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// if we specified a pubkey, it must be non-empty and valid
+	if (pubkey!=null)	{
+	    if (pubkey.isEmpty())	{
+		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "SSH public key may not be empty", HttpStatus.SC_BAD_REQUEST);
+	    }
+	    if (!isSSHPubKey(pubkey)) {
+		throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "key does not look like a SSH public key", HttpStatus.SC_BAD_REQUEST);
+	    }
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    logger.error("Cannot get SSHKeyStore");
+	    throw new GeneralException("Could not get SSH KeyStore"); 
+	}
+    
+	// Get existing pubkey
+	SSHKey value = store.get(new SSHKey(username, label));
+	if (value==null) {
+	    throw new OA2GeneralError("not_found", "No key to update found", HttpStatus.SC_NOT_FOUND);
+	}
+
+	// Update values
+	if (pubkey != null)    {
+	    value.setPubKey(pubkey);
+	}
+	if (description != null)    {
+	    value.setDescription(description);
+	}
+
+	// Update the pubkey
+	try {
+	    store.update(value);
+	} catch (Exception e)	{
+	    Throwable cause = e.getCause();
+	    if (cause == null)
+		logger.error("Cannot update key: "+e.getMessage());
+	    else
+		logger.error("Cannot update key: "+e.getMessage() + " (" + cause.getMessage() + ")");
+	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot update entry", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+	}
+    }
+
+    /**
+     * removes entry for given username and label
+     */
+    private void removeKey(String userName, String label) throws Throwable {
+	// username and label may not be empty
+	if (userName==null || userName.isEmpty())   {
+	    logger.error("Username is null or empty");
+	    throw new GeneralException("Cannot get username");
+	}
+	if (label==null || label.isEmpty()) {
+	    throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "Missing mandatory label", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    logger.error("Cannot get SSHKeyStore");
+	    throw new GeneralException("Could not get SSHKeyStore"); 
+	}
+
+	SSHKey key = null;
+	try {
+	    key = store.remove(new SSHKey(userName, label));
+	} catch (Exception e)	{
+	    Throwable cause = e.getCause();
+	    if (cause == null)
+		logger.error("Cannot remove key: "+e.getMessage());
+	    else
+		logger.error("Cannot remove key: "+e.getMessage() + " (" + cause.getMessage() + ")");
+	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot remove key", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+	}
+	if (key==null) {
+	    throw new OA2GeneralError("not_found", "No key found", HttpStatus.SC_NOT_FOUND);
+	}
+    }
+
+    /**
+     * retrieves entry for given username, label
+     */
+    private SSHKey getKey(String username, String label) throws Throwable {
+	// username and label may not be empty
+	if (username==null || username.isEmpty() || label==null || label.isEmpty()) {
+	    logger.error("Either username or label is empty");
+	    throw new GeneralException("Need username and label for getting key");
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    throw new GeneralException("Could not get SSH KeyStore"); 
+	}
+
+	SSHKey key = null;
+	try {
+	    key = store.get(new SSHKey(username, label));
+	} catch (Exception e)	{
+	    Throwable cause = e.getCause();
+	    if (cause == null)
+		logger.error("Cannot get key: "+e.getMessage());
+	    else
+		logger.error("Cannot get key: "+e.getMessage() + " (" + cause.getMessage() + ")");
+	    throw new OA2GeneralError(OA2Errors.SERVER_ERROR, "Cannot get key", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+	}
+	if (key==null) {
+	    throw new OA2GeneralError("not_found", "No key found", HttpStatus.SC_NOT_FOUND);
+	}
+    
+	return key;
+    }
+
+    /**
+     * lists all entries for given username
+     */
+    private List<SSHKey> getKeys(String userName) throws Throwable  {
+	// userName may not be empty
+	if (userName==null || userName.isEmpty()) {
+	    logger.error("Username is empty");
+	    throw new GeneralException("Cannot get username");
+	}
+
+	// try to get store
+	SQLSSHKeyStore store = (SQLSSHKeyStore)se.getSSHKeyStore();
+	if ( store == null) {
+	    throw new GeneralException("Could not get SSH KeyStore"); 
+	}
+
+	List<SSHKey> keys = store.getAll(userName);
+	if (keys==null) {
+	    throw new OA2GeneralError("not_found", "No key found", HttpStatus.SC_NOT_FOUND);
+	}
+    
+	return keys;
+    }
+
+
+    /**
+     * Writes each key to the response, using , as a separator between the
+     * columns
+     */
+    private void writeKeys(HttpServletResponse response, List<SSHKey> keys)    {
+	final char SEP = ',';
+	try {
+	    Writer writer = response.getWriter();
+	    for (SSHKey key : keys)	{
+		writer.write(key.getLabel());
+		writer.append(SEP);
+		writer.write(key.getUserName());
+		writer.append(SEP);
+		writer.write(key.getPubKey());
+		writer.append(SEP);
+		if (key.getDescription()!=null)
+		    writer.write(key.getDescription());
+		writer.append('\n');
+	    }
+	    writer.flush();
+	    writer.close();
+	} catch(IOException e)	{
+	    logger.error("Error: Cannot write keys: "+e.getMessage());
+	    throw new GeneralException("Cannot write keys");
+	}
+    }
+
+    private boolean isSSHPubKey(String key) {
+	int firstSpace=key.indexOf(' ');
+	if (firstSpace<0)   {
+	    logger.warn("Uploaded key does not contain a space");
+	    return false;
+	}
+
+	// Get type part: must start with ssh-
+	String type=key.substring(0, firstSpace);
+	if (! type.substring(0,4).equals(SSH_KEY_START))   {
+	    logger.warn("Uploaded key does not start with \""+SSH_KEY_START+"\"");
+	    return false;
+	}
+
+	// Get encoded part
+	int secondSpace=key.indexOf(' ', firstSpace+1);
+	String encoded;
+	if (secondSpace<0)  {
+	    encoded=key.substring(firstSpace+1);
+	} else	{
+	    encoded=key.substring(firstSpace+1,secondSpace);
+	}
+	try {
+	    byte[] decoded=Base64.getDecoder().decode(encoded);
+	} catch(IllegalArgumentException e) {
+	    logger.warn("Uploaded key does not contain base64-encoded part");
+	    return false;
+	}
+	return true;
+    }
+
+    /**
+     * Get access token from request, copy and paste from userinfo endpoint
+     */
+    private ServiceTransaction getAndVerifyTransaction(HttpServletRequest request) {
+	// Get access token: either bearer token or request parameter
+        AccessToken at = null;
+        List<String> authHeaders = getAuthHeader(request, "Bearer");
+
+        if(authHeaders.isEmpty()){
+            // it's not in a header, but was sent as a standard parameter.
+            at = se.getTokenForge().getAccessToken(request);
+        }else {
+            // only the very first one is taken. Don't try to snoop for them.
+            at = se.getTokenForge().getAccessToken(authHeaders.get(0));
+        }
+        if (at == null) {
+            // the bearer token should be sent in the authorization header.
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "no access token was sent.", HttpStatus.SC_BAD_REQUEST);
+        }
+
+	// Is it still valid
+	try {
+            checkTimestamp(at.getToken());
+        }catch(InvalidTimestampException itx){
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "token expired.", HttpStatus.SC_BAD_REQUEST);
+        }catch(NumberFormatException nfx)   {
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "invalid access token.", HttpStatus.SC_BAD_REQUEST);
+	}
+
+	// Now get the corresponding transaction and verify it's ok
+        ServiceTransaction transaction = null;
+	try {
+	    transaction = (ServiceTransaction) getTransactionStore().get(at);
+	} catch (Exception e)	{
+            logger.error("Error: Cannot get transaction for access_token: "+e.getMessage());
+            throw new GeneralException("Cannot get transaction for access_token");
+	}
+        if (transaction == null) {
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "no transaction for the access token was found.", HttpStatus.SC_BAD_REQUEST);
+        }
+        if (!transaction.isAccessTokenValid()) {
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST, "invalid access token.", HttpStatus.SC_BAD_REQUEST);
+        }
+
+        return transaction;
+    }
+
+    /**
+     * Copy and paste from OA2CertServlet, except we allow here an absent client
+     */
+    @Override
+    public Client getClient(HttpServletRequest req) {
+        String rawID = req.getParameter(CONST(CONSUMER_KEY));
+        String rawSecret = getFirstParameterValue(req, CLIENT_SECRET);
+        // According to the spec. this must be in anBasic Authz header if it is not sent as parameter
+        List<String> basicTokens = getAuthHeader(req, "Basic");
+        if (2 < basicTokens.size()) {
+            // too many tokens to unscramble
+            throw new OA2GeneralError(OA2Errors.INVALID_TOKEN,
+		    "Error: Too many authorization tokens.",
+		    HttpStatus.SC_FORBIDDEN);
+        }
+        if (rawID == null) {
+            // maybe it was sent as an authorization header
+            // now we have to check for which of these is the identifier
+
+            for (String x : basicTokens) {
+                try {
+                    // Here is some detective work. We get up to TWO basic Authz headers with the id and secret.
+                    // Since ids are valid URIs the idea here is anything that is uri must be an id and the other
+                    // one is the secret. This also handles the case that one of these is sent as a parameter
+                    // in the call and the other is in the header.
+                    URI test = URI.create(x);
+                    // It is possible that the secret may be parseable as a valid URI (plain strings are
+                    // trivially uris). This checks that there a
+                    // scheme, which implies this is an id. The other token is assumed to
+                    // be the secret.
+                    if (test.getScheme() != null) {
+                        rawID = x;
+                    } else {
+                        rawSecret = x;
+                    }
+                } catch (Throwable t) {
+                    if (rawSecret == null) {
+                        rawSecret = x;
+                    }
+                }
+            }
+        }
+        if (rawID == null) {
+	    // no client_id
+            return null;
+        }
+        Identifier id = BasicIdentifier.newID(rawID);
+        OA2Client client = (OA2Client) getClient(id);
+
+        if (rawSecret == null) {
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+                    "Error: No secret. request refused.",
+                    HttpStatus.SC_BAD_REQUEST);
+        }
+        if (!client.getSecret().equals(DigestUtils.shaHex(rawSecret))) {
+            throw new OA2GeneralError(OA2Errors.INVALID_REQUEST,
+                    "Error: Secret is incorrect. request refused.",
+                    HttpStatus.SC_FORBIDDEN);
+
+        }
+        return client;
+    }
+
+
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKey.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKey.java
@@ -93,6 +93,7 @@ public class SSHKey extends IdentifiableImpl {
     @Override
     public String toString() {
 	return "SSHKey: \n" + 
+	   "	label:      " + label + "\n" +
 	   "	username:   " + userName + "\n" +
 	   "	publickey:  " + pubKey + "\n"+
 	   "	description:" + description + "\n";

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKey.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKey.java
@@ -1,0 +1,102 @@
+package org.masterportal.oauth2.server.storage;
+
+import edu.uiuc.ncsa.security.core.Identifier;
+import edu.uiuc.ncsa.security.core.util.IdentifiableImpl;
+
+import static edu.uiuc.ncsa.security.core.util.BeanUtils.checkEquals;
+
+import java.util.List;
+
+
+public class SSHKey extends IdentifiableImpl {
+
+//    private static final long serialVersionUID = -7707448168067694856L;
+
+    protected String label;
+    protected String userName;
+    protected String pubKey;
+    protected String description;
+    
+    
+    public SSHKey(SSHKeyIdentifier identifier) {
+	super(identifier);
+    }
+
+    public SSHKey(String userName, String label) {
+	super(new SSHKeyIdentifier(userName, label));
+	this.userName=userName;
+	this.label=label;
+	this.pubKey=null;
+	this.description=null;
+    }
+    
+    public SSHKey(String userName, String label, String pubKey, String description) {
+	super(new SSHKeyIdentifier(userName, label));
+	this.userName=userName;
+	this.label=label;
+	this.pubKey=pubKey;
+	this.description=description;
+    }
+    
+    /* GETTERS AND SETTERS */
+    
+    public void setLabel(String label) {
+	this.label = label;
+    }
+    
+    public String getLabel() {
+	return label;
+    }
+    
+    public void setUserName(String userName) {
+	this.userName = userName;
+    }
+    
+    public String getUserName() {
+	return userName;
+    }
+    
+    public void setPubKey(String pubKey) {
+	this.pubKey = pubKey;
+    }
+    
+    public String getPubKey() {
+	return pubKey;
+    }
+    
+    public void setDescription(String description) {
+	this.description = description;
+    }
+    
+    public String getDescription() {
+	return description;
+    }
+    
+    
+    @Override
+    public void setIdentifier(Identifier identifier) {
+	super.setIdentifier(identifier);
+    }
+	    
+    @Override
+    public boolean equals(Object obj) {
+	if (super.equals(obj) && obj instanceof SSHKey) {
+	    SSHKey rec = (SSHKey) obj;
+	    if (checkEquals(getUserName(), rec.getUserName()) &&
+		checkEquals(getPubKey(), rec.getPubKey()) )	{
+		return true;
+	    }
+	}
+	return false;
+    }
+    
+    @Override
+    public String toString() {
+	return "SSHKey: \n" + 
+	   "	username:   " + userName + "\n" +
+	   "	publickey:  " + pubKey + "\n"+
+	   "	description:" + description + "\n";
+
+    }
+    
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKey.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKey.java
@@ -5,9 +5,12 @@ import edu.uiuc.ncsa.security.core.util.IdentifiableImpl;
 
 import static edu.uiuc.ncsa.security.core.util.BeanUtils.checkEquals;
 
-import java.util.List;
-
-
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * SSHKey objects describe individual SSH public keys: identified by the unique
+ * combination label, username, they further contain a single public key and an
+ * optional description.
+ */
 public class SSHKey extends IdentifiableImpl {
 
 //    private static final long serialVersionUID = -7707448168067694856L;
@@ -17,11 +20,18 @@ public class SSHKey extends IdentifiableImpl {
     protected String pubKey;
     protected String description;
     
-    
+    /**
+     * constructs an SSHKey from given identifier, note that this does not work
+     * properly as we don't fully implement SSHKeyIdentifier.
+     */
     public SSHKey(SSHKeyIdentifier identifier) {
 	super(identifier);
     }
 
+    /**
+     * constructs a new SSHKey for given userName and label. Public key and
+     * description are set to null.
+     */
     public SSHKey(String userName, String label) {
 	super(new SSHKeyIdentifier(userName, label));
 	this.userName=userName;
@@ -30,6 +40,10 @@ public class SSHKey extends IdentifiableImpl {
 	this.description=null;
     }
     
+    /**
+     * constructs a new SSHKey for given userName, label, public key and
+     * description.
+     */
     public SSHKey(String userName, String label, String pubKey, String description) {
 	super(new SSHKeyIdentifier(userName, label));
 	this.userName=userName;
@@ -39,49 +53,60 @@ public class SSHKey extends IdentifiableImpl {
     }
     
     /* GETTERS AND SETTERS */
-    
+   
+    /** set label */
     public void setLabel(String label) {
 	this.label = label;
     }
     
+    /** @return label */
     public String getLabel() {
 	return label;
     }
     
+    /** set username */
     public void setUserName(String userName) {
 	this.userName = userName;
     }
     
+    /** @return username */
     public String getUserName() {
 	return userName;
     }
     
+    /** set public key */
     public void setPubKey(String pubKey) {
 	this.pubKey = pubKey;
     }
     
+    /** @return public key */
     public String getPubKey() {
 	return pubKey;
     }
     
+    /** set description */
     public void setDescription(String description) {
 	this.description = description;
     }
     
+    /** @return description */
     public String getDescription() {
 	return description;
     }
     
-    
+    /** set identifier */
     @Override
     public void setIdentifier(Identifier identifier) {
 	super.setIdentifier(identifier);
     }
 	    
+    /** @return whether two keys have the same username and public key */
     @Override
     public boolean equals(Object obj) {
 	if (super.equals(obj) && obj instanceof SSHKey) {
 	    SSHKey rec = (SSHKey) obj;
+	    // TODO: perhaps should stick only to the pubKey, except that this
+	    // might still be null.
 	    if (checkEquals(getUserName(), rec.getUserName()) &&
 		checkEquals(getPubKey(), rec.getPubKey()) )	{
 		return true;
@@ -89,7 +114,8 @@ public class SSHKey extends IdentifiableImpl {
 	}
 	return false;
     }
-    
+   
+    /** @return printable representation of the key fields */
     @Override
     public String toString() {
 	return "SSHKey: \n" + 

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyConverter.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyConverter.java
@@ -1,0 +1,41 @@
+package org.masterportal.oauth2.server.storage;
+
+import edu.uiuc.ncsa.security.core.IdentifiableProvider;
+import edu.uiuc.ncsa.security.storage.data.ConversionMap;
+import edu.uiuc.ncsa.security.storage.data.MapConverter;
+import edu.uiuc.ncsa.security.storage.data.SerializationKeys;
+
+public class SSHKeyConverter<V extends SSHKey> extends MapConverter<V> {
+
+    public SSHKeyConverter(IdentifiableProvider<V> identifiableProvider) {
+        super(new SSHKeyKeys(), identifiableProvider);
+    }
+	
+    public SSHKeyConverter(SerializationKeys keys, IdentifiableProvider<V> provider) {
+	super(keys, provider);
+    }
+
+    private SSHKeyKeys getSKKeys() {
+	return (SSHKeyKeys) keys;
+    }
+    
+    @Override
+    public V fromMap(ConversionMap<String, Object> map, V v) {
+	v = super.fromMap(map, v);
+	
+	v.setLabel( map.getString( getSKKeys().label()) );
+	v.setUserName( map.getString( getSKKeys().username()) );
+	v.setPubKey( map.getString( getSKKeys().pub_key()) );
+	v.setDescription( map.getString( getSKKeys().description()) );
+	return v;
+    }
+    
+    @Override
+    public void toMap(V v, ConversionMap<String, Object> map) {
+	super.toMap(v, map);
+	map.put( getSKKeys().label() , v.getLabel());
+	map.put( getSKKeys().username() , v.getUserName());
+	map.put( getSKKeys().pub_key() , v.getPubKey());
+	map.put( getSKKeys().description() , v.getDescription());
+    }
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyConverter.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyConverter.java
@@ -5,6 +5,11 @@ import edu.uiuc.ncsa.security.storage.data.ConversionMap;
 import edu.uiuc.ncsa.security.storage.data.MapConverter;
 import edu.uiuc.ncsa.security.storage.data.SerializationKeys;
 
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * Provides the conversion methods to convert from the keys in the SQL table to
+ * the corresponding fields in the {@link SSHKey} object and vice versa.
+ */
 public class SSHKeyConverter<V extends SSHKey> extends MapConverter<V> {
 
     public SSHKeyConverter(IdentifiableProvider<V> identifiableProvider) {
@@ -24,8 +29,8 @@ public class SSHKeyConverter<V extends SSHKey> extends MapConverter<V> {
 	v = super.fromMap(map, v);
 	
 	v.setLabel( map.getString( getSKKeys().label()) );
-	v.setUserName( map.getString( getSKKeys().username()) );
-	v.setPubKey( map.getString( getSKKeys().pub_key()) );
+	v.setUserName( map.getString( getSKKeys().userName()) );
+	v.setPubKey( map.getString( getSKKeys().pubKey()) );
 	v.setDescription( map.getString( getSKKeys().description()) );
 	return v;
     }
@@ -34,8 +39,8 @@ public class SSHKeyConverter<V extends SSHKey> extends MapConverter<V> {
     public void toMap(V v, ConversionMap<String, Object> map) {
 	super.toMap(v, map);
 	map.put( getSKKeys().label() , v.getLabel());
-	map.put( getSKKeys().username() , v.getUserName());
-	map.put( getSKKeys().pub_key() , v.getPubKey());
+	map.put( getSKKeys().userName() , v.getUserName());
+	map.put( getSKKeys().pubKey() , v.getPubKey());
 	map.put( getSKKeys().description() , v.getDescription());
     }
 }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyIdentifier.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyIdentifier.java
@@ -1,0 +1,49 @@
+package org.masterportal.oauth2.server.storage;
+
+import java.net.URI;
+import edu.uiuc.ncsa.security.core.Identifier;
+
+public class SSHKeyIdentifier implements Identifier {
+
+	String identifier = null;
+	
+	public SSHKeyIdentifier(String userName, String label) {
+	    if (userName!=null && label!=null)	{
+		this.identifier = userName + ":" + label;
+	    }
+	}
+	
+	@Override
+	public int compareTo(Object o) {
+	    if ( o instanceof SSHKeyIdentifier ) {
+		return identifier.compareTo( ((SSHKeyIdentifier)o).identifier);
+	    } else {
+		return identifier.compareTo( o.toString() );
+	    }
+	}
+
+	@Override
+	public URI getUri() {
+	    return null;
+	}
+	
+	@Override
+	public String toString() {
+	    return identifier;
+	}
+
+	/* Override these two methods so that we can use this object as the
+	 * key in a hash lookup table
+	 */
+	
+	@Override
+	public boolean equals(Object obj) {
+	    return identifier.equals(obj.toString());
+	}
+
+	@Override
+	public int hashCode() {
+	    return identifier.hashCode();
+	}
+	
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyIdentifier.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyIdentifier.java
@@ -3,10 +3,21 @@ package org.masterportal.oauth2.server.storage;
 import java.net.URI;
 import edu.uiuc.ncsa.security.core.Identifier;
 
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * Note: we don't really use an Identifier for the SSHKey class (the unique
+ * combination of the two Strings, username and label is used a primary key).
+ * This class is only used in order to be able to reuse the SQL implementation
+ * of the Master Portal.
+ */
 public class SSHKeyIdentifier implements Identifier {
 
 	String identifier = null;
-	
+
+	/**
+	 * construct an identifier out of username and label, combining into
+	 * single String with colon as separator
+	 */
 	public SSHKeyIdentifier(String userName, String label) {
 	    if (userName!=null && label!=null)	{
 		this.identifier = userName + ":" + label;
@@ -22,6 +33,10 @@ public class SSHKeyIdentifier implements Identifier {
 	    }
 	}
 
+	/**
+	 * SSH Key identifiers don't have a URI representation.
+	 * @return null URI
+	 */
 	@Override
 	public URI getUri() {
 	    return null;
@@ -35,7 +50,6 @@ public class SSHKeyIdentifier implements Identifier {
 	/* Override these two methods so that we can use this object as the
 	 * key in a hash lookup table
 	 */
-	
 	@Override
 	public boolean equals(Object obj) {
 	    return identifier.equals(obj.toString());
@@ -45,5 +59,4 @@ public class SSHKeyIdentifier implements Identifier {
 	public int hashCode() {
 	    return identifier.hashCode();
 	}
-	
 }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyIdentifierProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyIdentifierProvider.java
@@ -3,6 +3,12 @@ package org.masterportal.oauth2.server.storage;
 import edu.uiuc.ncsa.security.core.Identifier;
 import edu.uiuc.ncsa.security.core.util.IdentifierProvider;
 
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * Note: we don't really use an Identifier for the SSH Keys, since they are
+ * identified by the unique combination of user and label, and the upstream
+ * Identifier class is not really suitable for that.
+ */
 public class SSHKeyIdentifierProvider extends IdentifierProvider {
 
     public SSHKeyIdentifierProvider() {

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyIdentifierProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyIdentifierProvider.java
@@ -1,0 +1,19 @@
+package org.masterportal.oauth2.server.storage;
+
+import edu.uiuc.ncsa.security.core.Identifier;
+import edu.uiuc.ncsa.security.core.util.IdentifierProvider;
+
+public class SSHKeyIdentifierProvider extends IdentifierProvider {
+
+    public SSHKeyIdentifierProvider() {
+	super("");
+    }
+	
+    @Override
+    public Identifier get() {
+	return (Identifier) new SSHKeyIdentifier(null, null);
+    }
+	
+
+	
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyKeys.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyKeys.java
@@ -2,41 +2,55 @@ package org.masterportal.oauth2.server.storage;
 
 import edu.uiuc.ncsa.security.storage.data.SerializationKeys;
 
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * Provides the table column keys for the different columns
+ */
 public class SSHKeyKeys extends SerializationKeys {
 
     public SSHKeyKeys() {
 	// the field declared as 'identifier' will be treated as a Primary Key
 //	identifier(serial);
     }
-   
+
+    /** column key of label column */
     String label = "label";
-    String username = "username";
-    String pub_key = "pub_key";
+    /** column key of userName column */
+    String userName = "username";
+    /** column key of pubKey column */
+    String pubKey = "pub_key";
+    /** column key of description column */
     String description = "description";
-    String import_time = "import_time";
-	
+    /** column key of importTime column */
+    String importTime = "import_time";
+
+    /** return column key for label column */
     public String label(String... x) {
         if (0 < x.length) label = x[0];
         return label;
     }
     
-    public String username(String... x) {
-        if (0 < x.length) username = x[0];
-        return username;
+    /** return column key for userName column */
+    public String userName(String... x) {
+        if (0 < x.length) userName = x[0];
+        return userName;
     }
     
-    public String pub_key(String... x) {
-        if (0 < x.length) pub_key = x[0];
-        return pub_key;
+    /** return column key for pubKey column */
+    public String pubKey(String... x) {
+        if (0 < x.length) pubKey = x[0];
+        return pubKey;
     }	
     
+    /** return column key for description column */
     public String description(String... x) {
         if (0 < x.length) description = x[0];
         return description;
     }	
     
-    public String import_time(String... x) {
-        if (0 < x.length) import_time = x[0];
-        return import_time;
+    /** return column key for importTime column */
+    public String importTime(String... x) {
+        if (0 < x.length) importTime = x[0];
+        return importTime;
     }	
 }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyKeys.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyKeys.java
@@ -1,0 +1,42 @@
+package org.masterportal.oauth2.server.storage;
+
+import edu.uiuc.ncsa.security.storage.data.SerializationKeys;
+
+public class SSHKeyKeys extends SerializationKeys {
+
+    public SSHKeyKeys() {
+	// the field declared as 'identifier' will be treated as a Primary Key
+//	identifier(serial);
+    }
+   
+    String label = "label";
+    String username = "username";
+    String pub_key = "pub_key";
+    String description = "description";
+    String import_time = "import_time";
+	
+    public String label(String... x) {
+        if (0 < x.length) label = x[0];
+        return label;
+    }
+    
+    public String username(String... x) {
+        if (0 < x.length) username = x[0];
+        return username;
+    }
+    
+    public String pub_key(String... x) {
+        if (0 < x.length) pub_key = x[0];
+        return pub_key;
+    }	
+    
+    public String description(String... x) {
+        if (0 < x.length) description = x[0];
+        return description;
+    }	
+    
+    public String import_time(String... x) {
+        if (0 < x.length) import_time = x[0];
+        return import_time;
+    }	
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyStore.java
@@ -1,0 +1,24 @@
+package org.masterportal.oauth2.server.storage;
+
+import java.util.List;
+
+import edu.uiuc.ncsa.security.core.Identifier;
+import edu.uiuc.ncsa.security.core.Store;
+
+public interface SSHKeyStore<V extends SSHKey> extends Store<V> {
+    public List<SSHKey> getAll();
+
+    public List<SSHKey> getAll(String username);
+
+    public void save(SSHKey value);
+
+    public void update(SSHKey value);
+
+    // get(Object) already defined in Map (hence in Store) as V get(Object)
+//    public SSHKey get(Object key);
+
+    // remove(Object) already defined in Map (hence in Store) as V remove(Object)
+//    public SSHKey remove(Object key);
+
+    public boolean containsKey(Object key);
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyStore.java
@@ -1,24 +1,41 @@
 package org.masterportal.oauth2.server.storage;
 
+import java.util.Collection;
 import java.util.List;
 
 import edu.uiuc.ncsa.security.core.Store;
 
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * Basic interface for a store of SSHKey.
+ * @see SQLSSHKeyStore
+ */
 public interface SSHKeyStore<V extends SSHKey> extends Store<V> {
-    // Can use values() instead
-//  public List<SSHKey> getAll();
 
-    public List<SSHKey> getAll(String username);
+    /** @return current list of all SSHKey. */
+    @Override
+    public Collection<V> values();
 
+    /** @return current list of SSHKey for given username */
+    public List<SSHKey> getAll(String userName);
+
+    /** adds a new {@link SSHKey} into the store. */
+    @Override
     public void save(SSHKey value);
 
+    /** updates an existing {@link SSHKey} in the store. */
+    @Override
     public void update(SSHKey value);
 
-    // get(Object) already defined in Map (hence in Store) as V get(Object)
-//    public SSHKey get(Object key);
+    /** @return {@link SSHKey} from the store. */
+    @Override
+    public V get(Object key);
 
-    // remove(Object) already defined in Map (hence in Store) as V remove(Object)
-//    public SSHKey remove(Object key);
+    /** removes key from store. */
+    @Override
+    public V remove(Object key);
 
+    /** @return whether key is present in store. */
+    @Override
     public boolean containsKey(Object key);
 }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyStore.java
@@ -2,10 +2,10 @@ package org.masterportal.oauth2.server.storage;
 
 import java.util.List;
 
-import edu.uiuc.ncsa.security.core.Identifier;
 import edu.uiuc.ncsa.security.core.Store;
 
 public interface SSHKeyStore<V extends SSHKey> extends Store<V> {
+    // TODO MISCHA : probably don't need this one
     public List<SSHKey> getAll();
 
     public List<SSHKey> getAll(String username);

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/SSHKeyStore.java
@@ -5,8 +5,8 @@ import java.util.List;
 import edu.uiuc.ncsa.security.core.Store;
 
 public interface SSHKeyStore<V extends SSHKey> extends Store<V> {
-    // TODO MISCHA : probably don't need this one
-    public List<SSHKey> getAll();
+    // Can use values() instead
+//  public List<SSHKey> getAll();
 
     public List<SSHKey> getAll(String username);
 

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/MultiSSHKeyStoreProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/MultiSSHKeyStoreProvider.java
@@ -1,12 +1,17 @@
 package org.masterportal.oauth2.server.storage.impl;
 
-import org.apache.commons.configuration.tree.ConfigurationNode;
 import org.masterportal.oauth2.server.storage.SSHKey;
 import org.masterportal.oauth2.server.storage.SSHKeyStore;
 
 import edu.uiuc.ncsa.security.core.exceptions.NotImplementedException;
 import edu.uiuc.ncsa.security.core.util.MyLoggingFacade;
 
+import org.apache.commons.configuration.tree.ConfigurationNode;
+
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * a {@link SSHKeyStoreProvider} without a default store.
+ */
 public class MultiSSHKeyStoreProvider<T extends SSHKey> extends SSHKeyStoreProvider<SSHKeyStore<T>> {
 
     public MultiSSHKeyStoreProvider(ConfigurationNode config, boolean disableDefaultStore, MyLoggingFacade logger, String type, String target) {

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/MultiSSHKeyStoreProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/MultiSSHKeyStoreProvider.java
@@ -1,0 +1,23 @@
+package org.masterportal.oauth2.server.storage.impl;
+
+import java.util.List;
+
+import org.apache.commons.configuration.tree.ConfigurationNode;
+import org.masterportal.oauth2.server.storage.SSHKey;
+import org.masterportal.oauth2.server.storage.SSHKeyStore;
+
+import edu.uiuc.ncsa.security.core.configuration.provider.CfgEvent;
+import edu.uiuc.ncsa.security.core.exceptions.NotImplementedException;
+import edu.uiuc.ncsa.security.core.util.MyLoggingFacade;
+
+public class MultiSSHKeyStoreProvider<T extends SSHKey> extends SSHKeyStoreProvider<SSHKeyStore<T>> {
+
+    public MultiSSHKeyStoreProvider(ConfigurationNode config, boolean disableDefaultStore, MyLoggingFacade logger, String type, String target) {
+    	super(config, disableDefaultStore, logger, type, target);
+    }
+
+    @Override
+    public SSHKeyStore<T> getDefaultStore() {
+	throw new NotImplementedException("SSHKeyStoreProvider does not have a default store. Yet.");
+    }
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/MultiSSHKeyStoreProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/MultiSSHKeyStoreProvider.java
@@ -1,12 +1,9 @@
 package org.masterportal.oauth2.server.storage.impl;
 
-import java.util.List;
-
 import org.apache.commons.configuration.tree.ConfigurationNode;
 import org.masterportal.oauth2.server.storage.SSHKey;
 import org.masterportal.oauth2.server.storage.SSHKeyStore;
 
-import edu.uiuc.ncsa.security.core.configuration.provider.CfgEvent;
 import edu.uiuc.ncsa.security.core.exceptions.NotImplementedException;
 import edu.uiuc.ncsa.security.core.util.MyLoggingFacade;
 

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/SSHKeyProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/SSHKeyProvider.java
@@ -1,11 +1,16 @@
 package org.masterportal.oauth2.server.storage.impl;
 
-import javax.inject.Provider;
-
 import org.masterportal.oauth2.server.storage.SSHKey;
 
 import edu.uiuc.ncsa.security.core.Identifier;
 import edu.uiuc.ncsa.security.core.util.IdentifiableProviderImpl;
+
+import javax.inject.Provider;
+
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * Provider Class for {@link SSHKey} objects.
+ */
 
 public class SSHKeyProvider extends IdentifiableProviderImpl<SSHKey> {
 
@@ -13,9 +18,12 @@ public class SSHKeyProvider extends IdentifiableProviderImpl<SSHKey> {
 	super(idProvider);
     }
 
+    /**
+     * @return new SSHKey object with a null identifier (since we don't really
+     * use a single-value identifier.
+     */
     @Override
     public SSHKey get(boolean createNewIdentifier) {
 	return new SSHKey(null);
     }
-	
 }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/SSHKeyProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/SSHKeyProvider.java
@@ -1,0 +1,21 @@
+package org.masterportal.oauth2.server.storage.impl;
+
+import javax.inject.Provider;
+
+import org.masterportal.oauth2.server.storage.SSHKey;
+
+import edu.uiuc.ncsa.security.core.Identifier;
+import edu.uiuc.ncsa.security.core.util.IdentifiableProviderImpl;
+
+public class SSHKeyProvider extends IdentifiableProviderImpl<SSHKey> {
+
+    public SSHKeyProvider(Provider<Identifier> idProvider) {
+	super(idProvider);
+    }
+
+    @Override
+    public SSHKey get(boolean createNewIdentifier) {
+	return new SSHKey(null);
+    }
+	
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/SSHKeyStoreProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/SSHKeyStoreProvider.java
@@ -1,10 +1,16 @@
 package org.masterportal.oauth2.server.storage.impl;
 
-import org.apache.commons.configuration.tree.ConfigurationNode;
 import org.masterportal.oauth2.server.storage.SSHKeyStore;
 
 import edu.uiuc.ncsa.security.core.configuration.provider.MultiTypeProvider;
 import edu.uiuc.ncsa.security.core.util.MyLoggingFacade;
+
+import org.apache.commons.configuration.tree.ConfigurationNode;
+
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * Provider class for {@link SSHKeyStore} objects
+ */
 
 public abstract class SSHKeyStoreProvider<T extends SSHKeyStore> extends MultiTypeProvider<T> {
 

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/SSHKeyStoreProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/impl/SSHKeyStoreProvider.java
@@ -1,0 +1,15 @@
+package org.masterportal.oauth2.server.storage.impl;
+
+import org.apache.commons.configuration.tree.ConfigurationNode;
+import org.masterportal.oauth2.server.storage.SSHKeyStore;
+
+import edu.uiuc.ncsa.security.core.configuration.provider.MultiTypeProvider;
+import edu.uiuc.ncsa.security.core.util.MyLoggingFacade;
+
+public abstract class SSHKeyStoreProvider<T extends SSHKeyStore> extends MultiTypeProvider<T> {
+
+    public SSHKeyStoreProvider(ConfigurationNode config, boolean disableDefaultStore, MyLoggingFacade logger, String type, String target) {
+    	super(config, disableDefaultStore, logger, type, target);
+    }
+	
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
@@ -41,42 +41,9 @@ public class SQLSSHKeyStore extends SQLStore<SSHKey> implements SSHKeyStore<SSHK
     }
 
     /**
-     * Get all entries in the DB
-     */
-    public List<SSHKey> getAll()    {
-	Connection c = getConnection();
-	List<SSHKey> resultSet = new ArrayList<SSHKey>();
-	try {
-	    PreparedStatement stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createAllSelectStatement() );
-	    stmt.executeQuery();
-	    ResultSet rs = stmt.getResultSet();
-	    
-	    // iterate over result set
-	    while ( rs.next() ) {
-		ColumnMap map = rsToMap(rs);
-		SSHKey t = create();
-		populate(map, t);
-		resultSet.add(t);
-	    }
-	    rs.close();
-	    stmt.close();
-	} catch (SQLException e) {
-	    destroyConnection(c);
-	    throw new GeneralException("Error getting SSH keys", e);
-	} finally {
-	    releaseConnection(c);
-	}
-
-	if ( resultSet.isEmpty() ) {
-	    return null;
-	} 
-	
-	return resultSet;
-    }
-
-    /**
      * Get all entries in the DB for given username
      */
+    @Override
     public List<SSHKey> getAll(String username)    {
 	Connection c = getConnection();
 	List<SSHKey> resultSet = new ArrayList<SSHKey>();

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
@@ -12,13 +12,10 @@ import java.util.List;
 import javax.inject.Provider;
 
 import org.masterportal.oauth2.server.storage.SSHKey;
-import org.masterportal.oauth2.server.storage.SSHKeyKeys;
 import org.masterportal.oauth2.server.storage.SSHKeyStore;
 import org.masterportal.oauth2.server.storage.sql.table.SSHKeyTable;
 
-import edu.uiuc.ncsa.security.core.Identifier;
 import edu.uiuc.ncsa.security.core.exceptions.GeneralException;
-import edu.uiuc.ncsa.security.core.exceptions.NFWException;
 import edu.uiuc.ncsa.security.core.util.BasicIdentifier;
 import edu.uiuc.ncsa.security.storage.data.MapConverter;
 import edu.uiuc.ncsa.security.storage.sql.ConnectionPool;
@@ -30,8 +27,7 @@ import edu.uiuc.ncsa.security.storage.sql.internals.Table;
 import static java.sql.Types.LONGVARCHAR;
 
 public class SQLSSHKeyStore extends SQLStore<SSHKey> implements SSHKeyStore<SSHKey> {
-
-    public static final String DEFAULT_TABLENAME =  "ssh_keys";
+    public static final String DEFAULT_TABLENAME = "ssh_keys";
 
     private static final String USERNAME_COLUMN =   "username";
     private static final String LABEL_COLUMN =	    "label";

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
@@ -70,10 +70,7 @@ public class SQLSSHKeyStore extends SQLStore<SSHKey> implements SSHKeyStore<SSHK
 	    releaseConnection(c);
 	}
 
-	if (  resultSet.isEmpty() ) {
-	    return null;
-	} 
-	
+	// Even return resultSet if it is an empty set
 	return resultSet;
     }
 

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
@@ -248,18 +248,12 @@ public class SQLSSHKeyStore extends SQLStore<SSHKey> implements SSHKeyStore<SSHK
 	SSHKey out = null;
 
         Connection c = getConnection();
-	PreparedStatement stmt = null;
         try {
-//	    PreparedStatement stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createSelectStatement() );
-	    stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createSelectStatement() );
+	    PreparedStatement stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createSelectStatement() );
             stmt.setString(1, value.getUserName());
             stmt.setString(2, value.getLabel());
 
 	    stmt.execute();// just execute() since executeQuery(x) would throw an exception regardless of content of x as per JDBC spec.
-	} catch (SQLException e)    {
-	    throw new GeneralException("1. Error getting key: "+e.getMessage());
-	}
-	try{
 	    ResultSet rs = stmt.getResultSet();
 	    if (rs.next())  {	// Need to move to the first element (if available)
 		ColumnMap map = rsToMap(rs);
@@ -270,7 +264,7 @@ public class SQLSSHKeyStore extends SQLStore<SSHKey> implements SSHKeyStore<SSHK
             stmt.close();
         } catch (SQLException e) {
             destroyConnection(c);
-            throw new GeneralException("2. Error getting key: "+e.getMessage());
+            throw new GeneralException("Error getting key", e);
         } finally {
             releaseConnection(c);
         }

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
@@ -163,35 +163,6 @@ public class SQLSSHKeyStore extends SQLStore<SSHKey> implements SSHKeyStore<SSHK
     }
 
     /**
-     * Returns new unique label for username
-     */
-    public String createLabel(String userName)	{
-	final String PREFIX="ssh-key-";
-
-	try {
-	    List<SSHKey> keys = getAll(userName);
-	    if (keys!=null) {
-		// Loop backwards over keys until we find matching ssh-key-[0-9]\+
-		for (int i=keys.size()-1; i>=0 ; i--) {
-		    String label=keys.get(i).getLabel();
-		    if (label.matches(PREFIX+"[0-9]+"))    {
-			// Found the last one, now get the suffix, add one and
-			// create the new label
-			int newSerial=1+Integer.parseInt(label.substring(PREFIX.length()));
-			return PREFIX+Integer.toString(newSerial);
-		    }
-		}
-	    }
-	} catch (GeneralException e)	{
-	    throw new GeneralException("Error obtaining key list: "+e.getMessage(), e.getCause());
-	} catch (Exception e)	{
-	    throw new GeneralException("Error obtaining key list", e);
-	}
-	// No matches, will use new default
-	return PREFIX+"1";
-    }
-
-    /**
      * Overrides update(V ) in SQLStore, implements update(SSHKey in SQLSSHKeyStore
      */
     @Override

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStore.java
@@ -1,0 +1,341 @@
+package org.masterportal.oauth2.server.storage.sql;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import javax.inject.Provider;
+
+import org.masterportal.oauth2.server.storage.SSHKey;
+import org.masterportal.oauth2.server.storage.SSHKeyKeys;
+import org.masterportal.oauth2.server.storage.SSHKeyStore;
+import org.masterportal.oauth2.server.storage.sql.table.SSHKeyTable;
+
+import edu.uiuc.ncsa.security.core.Identifier;
+import edu.uiuc.ncsa.security.core.exceptions.GeneralException;
+import edu.uiuc.ncsa.security.core.exceptions.NFWException;
+import edu.uiuc.ncsa.security.core.util.BasicIdentifier;
+import edu.uiuc.ncsa.security.storage.data.MapConverter;
+import edu.uiuc.ncsa.security.storage.sql.ConnectionPool;
+import edu.uiuc.ncsa.security.storage.sql.SQLStore;
+import edu.uiuc.ncsa.security.storage.sql.internals.ColumnDescriptorEntry;
+import edu.uiuc.ncsa.security.storage.sql.internals.ColumnMap;
+import edu.uiuc.ncsa.security.storage.sql.internals.Table;
+
+import static java.sql.Types.LONGVARCHAR;
+
+public class SQLSSHKeyStore extends SQLStore<SSHKey> implements SSHKeyStore<SSHKey> {
+
+    public static final String DEFAULT_TABLENAME =  "ssh_keys";
+
+    private static final String USERNAME_COLUMN =   "username";
+    private static final String LABEL_COLUMN =	    "label";
+
+	
+    public SQLSSHKeyStore(ConnectionPool connectionPool,
+            Table table,
+            Provider<SSHKey> identifiableProvider,
+            MapConverter converter) {
+    	super(connectionPool, table, identifiableProvider, converter);
+    }
+
+    /**
+     * Get all entries in the DB
+     */
+    public List<SSHKey> getAll()    {
+	Connection c = getConnection();
+	List<SSHKey> resultSet = new ArrayList<SSHKey>();
+	try {
+	    PreparedStatement stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createAllSelectStatement() );
+	    stmt.executeQuery();
+	    ResultSet rs = stmt.getResultSet();
+	    
+	    // iterate over result set
+	    while ( rs.next() ) {
+		ColumnMap map = rsToMap(rs);
+		SSHKey t = create();
+		populate(map, t);
+		resultSet.add(t);
+	    }
+	    rs.close();
+	    stmt.close();
+	} catch (SQLException e) {
+	    destroyConnection(c);
+	    throw new GeneralException("Error getting SSH keys", e);
+	} finally {
+	    releaseConnection(c);
+	}
+
+	if ( resultSet.isEmpty() ) {
+	    return null;
+	} 
+	
+	return resultSet;
+    }
+
+    /**
+     * Get all entries in the DB for given username
+     */
+    public List<SSHKey> getAll(String username)    {
+	Connection c = getConnection();
+	List<SSHKey> resultSet = new ArrayList<SSHKey>();
+	try {
+	    PreparedStatement stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createUserSelectStatement());
+	    stmt.setString(1, username);
+
+	    stmt.executeQuery();
+	    ResultSet rs = stmt.getResultSet();
+	    
+	    // iterate over result set
+	    while ( rs.next() ) {
+		ColumnMap map = rsToMap(rs);
+		SSHKey t = create();
+		populate(map, t);
+		resultSet.add(t);
+	    }
+	    rs.close();
+	    stmt.close();
+	} catch (SQLException e) {
+	    destroyConnection(c);
+	    throw new GeneralException("Error getting SSH keys for " + username, e);
+	} finally {
+	    releaseConnection(c);
+	}
+
+	if (  resultSet.isEmpty() ) {
+	    return null;
+	} 
+	
+	return resultSet;
+    }
+
+    /**
+     * Adds key to the username
+     */
+    @Override
+    public void save(SSHKey value)  {
+	/* Just a wrapper around register */
+	register(value);
+    }
+
+    /**
+     * Adds key to the username
+     */
+    @Override
+    public void register(SSHKey value) {
+        Connection c = getConnection();
+
+	try {
+	    String tableName = getTable().getTablename();
+	    ResultSet res = c.getMetaData().getTables(null, null, tableName, new String[] {"TABLE"});
+	    if (res.next() == false)    {
+		throw new GeneralException("Cannot find table "+tableName);
+	    }
+
+	    SSHKeyTable table = (SSHKeyTable)getTable();
+            PreparedStatement stmt = c.prepareStatement( table.createInsertStatement() );
+            ColumnMap map = depopulate(value);
+            int i = 1;
+            for (ColumnDescriptorEntry cde : table.getColumnDescriptor()) {
+                // now we loop through the table and set each and every one of these
+                // OAUTH-148 fix: MariaDB driver does not accept longvarchar as a type in setObject (known bug for
+                // them. Workaround is to explicitly test for this and carry out a setString call instead.
+                if (cde.getType() == LONGVARCHAR) {
+                    Object obj = map.get(cde.getName());
+                    stmt.setString(i++, obj == null ? null : obj.toString());
+                } else {
+                    stmt.setObject(i++, map.get(cde.getName()), cde.getType());
+                }
+            }
+            stmt.execute();// just execute() since executeQuery(x) would throw an exception regardless of content of x as per JDBC spec.
+            stmt.close();
+        } catch (SQLException e) {
+            destroyConnection(c);
+            throw new GeneralException("Error registering entry for username=" + value.getUserName() + " label=" + value.getLabel(), e);
+        } finally {
+            releaseConnection(c);
+        }
+    }
+
+    /**
+     * Returns new unique label for username
+     */
+    public String createLabel(String userName)	{
+	final String PREFIX="ssh-key-";
+
+	try {
+	    List<SSHKey> keys = getAll(userName);
+	    if (keys!=null) {
+		// Loop backwards over keys until we find matching ssh-key-[0-9]\+
+		for (int i=keys.size()-1; i>=0 ; i--) {
+		    String label=keys.get(i).getLabel();
+		    if (label.matches(PREFIX+"[0-9]+"))    {
+			// Found the last one, now get the suffix, add one and
+			// create the new label
+			int newSerial=1+Integer.parseInt(label.substring(PREFIX.length()));
+			return PREFIX+Integer.toString(newSerial);
+		    }
+		}
+	    }
+	} catch (GeneralException e)	{
+	    throw new GeneralException("Error obtaining key list: "+e.getMessage(), e.getCause());
+	} catch (Exception e)	{
+	    throw new GeneralException("Error obtaining key list", e);
+	}
+	// No matches, will use new default
+	return PREFIX+"1";
+    }
+
+    /**
+     * Overrides update(V ) in SQLStore, implements update(SSHKey in SQLSSHKeyStore
+     */
+    @Override
+    public void update(SSHKey value) {
+        Connection c = getConnection();
+        try {
+	    SSHKeyTable table = (SSHKeyTable)getTable();
+            PreparedStatement stmt = c.prepareStatement( table.createUpdateStatement() );
+            ColumnMap map = depopulate(value);
+            int i = 1;
+            for (ColumnDescriptorEntry cde : table.getColumnDescriptor()) {
+                // now we loop through the table and set each and every one of these
+		String name = cde.getName();
+		// Only can update the non-username, non-label entries
+                if (!name.equals(USERNAME_COLUMN) && !name.equals(LABEL_COLUMN)) {
+                    Object obj = map.get(name);
+                    // Dates confuse setObject, so turn it into an SQL Timestamp object.
+                    if (obj instanceof Date) {
+                        obj = new Timestamp(((Date) obj).getTime());
+                    }
+                    if (obj instanceof BasicIdentifier) {
+                        stmt.setString(i++, obj.toString());
+                    } else {
+                        stmt.setObject(i++, obj);
+                    }
+                }
+            }
+
+            // now set the matching keys: userName and label
+            stmt.setString(i++, value.getUserName());
+            stmt.setString(i++, value.getLabel());
+            
+            stmt.executeUpdate();
+            stmt.close();
+
+        } catch (SQLException e) {
+            destroyConnection(c);
+            throw new GeneralException("Error updating entry for username=" + value.getUserName() + " label=" + value.getLabel(), e);
+        } finally {
+            releaseConnection(c);
+        }
+		
+    }
+
+    /**
+     * Overrides get() in SQLStore
+     */
+    @Override
+    public SSHKey get(Object key) {
+	if ( !(key instanceof SSHKey) ) {
+            throw new GeneralException("input key must be a SSHKey");
+	}
+	SSHKey value = (SSHKey) key;
+	SSHKey out = null;
+
+        Connection c = getConnection();
+	PreparedStatement stmt = null;
+        try {
+//	    PreparedStatement stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createSelectStatement() );
+	    stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createSelectStatement() );
+            stmt.setString(1, value.getUserName());
+            stmt.setString(2, value.getLabel());
+
+	    stmt.execute();// just execute() since executeQuery(x) would throw an exception regardless of content of x as per JDBC spec.
+	} catch (SQLException e)    {
+	    throw new GeneralException("1. Error getting key: "+e.getMessage());
+	}
+	try{
+	    ResultSet rs = stmt.getResultSet();
+	    if (rs.next())  {	// Need to move to the first element (if available)
+		ColumnMap map = rsToMap(rs);
+		out = create();
+		populate(map, out);
+	    }
+	    rs.close();
+            stmt.close();
+        } catch (SQLException e) {
+            destroyConnection(c);
+            throw new GeneralException("2. Error getting key: "+e.getMessage());
+        } finally {
+            releaseConnection(c);
+        }
+        return out;
+    }
+
+    /**
+     * Overrides remove() in SQLStore
+     */
+    @Override
+    public SSHKey remove(Object key) {
+	if ( !(key instanceof SSHKey) ) {
+            throw new GeneralException("input key must be a SSHKey");
+	}
+	SSHKey value = (SSHKey)key;
+	SSHKey oldObject = null;
+        try {
+            oldObject = get(value);
+        } catch (GeneralException x) {
+            return null;
+        }
+
+        Connection c = getConnection();
+        try {
+	    PreparedStatement stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createDeleteStatement() );
+            stmt.setString(1, value.getUserName());
+            stmt.setString(2, value.getLabel());
+            stmt.execute();
+            stmt.close();
+        } catch (SQLException e) {
+            destroyConnection(c);
+            throw new GeneralException("Error removing key", e);
+        } finally {
+            releaseConnection(c);
+        }
+        return oldObject;
+    }
+
+    /**
+     * Returns whether the pubkey already exists
+     * Overrides containsKey() in SQLStore
+     */
+    @Override
+    public boolean containsKey(Object key) {
+	if ( !(key instanceof SSHKey) ) {
+            throw new GeneralException("input key must be a SSHKey");
+	}
+	SSHKey value = (SSHKey) key;
+	    
+	Connection c = getConnection();
+	boolean rc = false;
+	try {
+	    PreparedStatement stmt = c.prepareStatement( ((SSHKeyTable)getTable()).createKeySelectStatement() );
+	    stmt.setString(1, value.getPubKey());
+	    stmt.execute();// just execute() since executeQuery(x) would throw an exception regardless of content of x as per JDBC spec.
+	    ResultSet rs = stmt.getResultSet();
+	    rc = rs.next();
+	    rs.close();
+	    stmt.close();
+	} catch (SQLException e) {
+	    destroyConnection(c);
+	    e.printStackTrace();
+	} finally {
+	    releaseConnection(c);
+	}
+	return rc;		
+    }
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStoreProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStoreProvider.java
@@ -1,8 +1,6 @@
 package org.masterportal.oauth2.server.storage.sql;
 
-import javax.inject.Provider;
 
-import org.apache.commons.configuration.tree.ConfigurationNode;
 import org.masterportal.oauth2.servlet.MPOA4MPConfigTags;
 import org.masterportal.oauth2.server.storage.SSHKey;
 import org.masterportal.oauth2.server.storage.SSHKeyKeys;
@@ -13,6 +11,15 @@ import edu.uiuc.ncsa.security.storage.sql.ConnectionPool;
 import edu.uiuc.ncsa.security.storage.sql.ConnectionPoolProvider;
 import edu.uiuc.ncsa.security.storage.sql.SQLStoreProvider;
 import edu.uiuc.ncsa.security.storage.sql.internals.Table;
+
+import org.apache.commons.configuration.tree.ConfigurationNode;
+
+import javax.inject.Provider;
+
+/**
+ * <p>Created by Mischa Sall&eacute;<br>
+ * Provider class for (@link SQLSSHKeyStore} objects.
+ */
 
 public class SQLSSHKeyStoreProvider<V extends SQLSSHKeyStore> extends SQLStoreProvider<V> {
 

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStoreProvider.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/SQLSSHKeyStoreProvider.java
@@ -1,0 +1,53 @@
+package org.masterportal.oauth2.server.storage.sql;
+
+import javax.inject.Provider;
+
+import org.apache.commons.configuration.tree.ConfigurationNode;
+import org.masterportal.oauth2.servlet.MPOA4MPConfigTags;
+import org.masterportal.oauth2.server.storage.SSHKey;
+import org.masterportal.oauth2.server.storage.SSHKeyKeys;
+import org.masterportal.oauth2.server.storage.sql.table.SSHKeyTable;
+
+import edu.uiuc.ncsa.security.storage.data.MapConverter;
+import edu.uiuc.ncsa.security.storage.sql.ConnectionPool;
+import edu.uiuc.ncsa.security.storage.sql.ConnectionPoolProvider;
+import edu.uiuc.ncsa.security.storage.sql.SQLStoreProvider;
+import edu.uiuc.ncsa.security.storage.sql.internals.Table;
+
+public class SQLSSHKeyStoreProvider<V extends SQLSSHKeyStore> extends SQLStoreProvider<V> {
+
+    protected Provider<SSHKey> sshKeyProvider;
+	
+    public SQLSSHKeyStoreProvider(
+            ConfigurationNode config,
+            ConnectionPoolProvider<? extends ConnectionPool> cpp,
+            String type,
+            String target,
+            String tablename,
+            MapConverter converter,
+            Provider<SSHKey> provider) {
+        super(config, cpp, type, target, tablename, converter);
+        this.sshKeyProvider = provider;
+    }
+
+    public SQLSSHKeyStoreProvider(
+            ConfigurationNode config,
+            ConnectionPoolProvider<? extends ConnectionPool> cpp,
+            String type,
+            MapConverter converter,
+            Provider<SSHKey> provider) {
+        super(config, cpp, type, MPOA4MPConfigTags.SSH_KEY_STORE, SQLSSHKeyStore.DEFAULT_TABLENAME, converter);
+        this.sshKeyProvider = provider;
+    }
+     
+    @Override
+    public V newInstance(Table table) {
+    	return (V) new SQLSSHKeyStore(getConnectionPool(), table, sshKeyProvider, converter);
+    }
+    
+    @Override
+    public V get() {
+    	return newInstance( new SSHKeyTable( (SSHKeyKeys) converter.keys, getSchema(), getPrefix(), getTablename()));
+    }
+    
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
@@ -6,8 +6,6 @@ import edu.uiuc.ncsa.security.storage.sql.internals.ColumnDescriptorEntry;
 import edu.uiuc.ncsa.security.storage.sql.internals.Table;
 
 import static java.sql.Types.VARCHAR;
-import static java.sql.Types.INTEGER;
-import static java.sql.Types.TIMESTAMP;
 
 public class SSHKeyTable extends Table {
     private final String TIME_LABEL = "import_time";

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
@@ -61,7 +61,7 @@ public class SSHKeyTable extends Table {
 
 	select += x.userName() + " =?";
         
-	select += " ORDER BY "+x.label()+" ASC";
+	select += " ORDER BY "+x.importTime()+" DESC";
 
         return select;
     }    

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
@@ -43,19 +43,6 @@ public class SSHKeyTable extends Table {
     }
 
     /**
-     * Creates statement to obtain all entries ordered by username,label
-     */
-    public String createAllSelectStatement(){
-        SSHKeyKeys x =  (SSHKeyKeys) keys;
-    	String select =  "SELECT * FROM " + getFQTablename();
-
-        select += " ORDER BY "+x.username()+","+x.label()+" ASC";
-        
-        return select;
-    }
-
-
-    /**
      * Creates statement to obtain all entries for a single username
      */
     public String createUserSelectStatement(){

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
@@ -1,0 +1,154 @@
+package org.masterportal.oauth2.server.storage.sql.table;
+
+import org.masterportal.oauth2.server.storage.SSHKeyKeys;
+
+import edu.uiuc.ncsa.security.storage.sql.internals.ColumnDescriptorEntry;
+import edu.uiuc.ncsa.security.storage.sql.internals.Table;
+
+import static java.sql.Types.VARCHAR;
+import static java.sql.Types.INTEGER;
+import static java.sql.Types.TIMESTAMP;
+
+public class SSHKeyTable extends Table {
+    private final String TIME_LABEL = "import_time";
+
+
+    public SSHKeyTable(SSHKeyKeys keys, String schema, String tablenamePrefix, String tablename) {
+        super(keys, schema, tablenamePrefix, tablename);
+    }
+	
+    @Override
+    public void createColumnDescriptors() {
+//    	super.createColumnDescriptors();
+    	SSHKeyKeys x =  (SSHKeyKeys) keys;
+
+	// We will be using the pair username,label as a composite primary key
+
+	// label must be only unique per user, so not primary, must be present
+    	getColumnDescriptor().add(new ColumnDescriptorEntry(x.label(), VARCHAR, false, false));
+
+	// username can have multiple keys, so do not declare primary, must be present
+    	getColumnDescriptor().add(new ColumnDescriptorEntry(x.username(), VARCHAR, false, false));
+
+	// pubkey must be unique for ssh, also must be present, but don't make
+	// it present as we want to be able to change it
+    	getColumnDescriptor().add(new ColumnDescriptorEntry(x.pub_key(), VARCHAR, false, false));
+	
+	// description is optional
+    	getColumnDescriptor().add(new ColumnDescriptorEntry(x.description(), VARCHAR));
+
+	// Don't create TIMESTAMP row, since it will fail with the
+	// getColumnDescriptor() used in e.g. creation e.g. in
+	// createRegisterStatement() in createInsertStatement() below and also
+	// in createUpdateStatement(). Unfortunately, table creation does not
+	// order the rows...
+    }
+
+    /**
+     * Creates statement to obtain all entries ordered by username,label
+     */
+    public String createAllSelectStatement(){
+        SSHKeyKeys x =  (SSHKeyKeys) keys;
+    	String select =  "SELECT * FROM " + getFQTablename();
+
+        select += " ORDER BY "+x.username()+","+x.label()+" ASC";
+        
+        return select;
+    }
+
+
+    /**
+     * Creates statement to obtain all entries for a single username
+     */
+    public String createUserSelectStatement(){
+        SSHKeyKeys x =  (SSHKeyKeys) keys;
+    	String select =  "SELECT * FROM " + getFQTablename() + " WHERE ";
+
+	select += x.username() + " =?";
+        
+	select += " ORDER BY "+x.label()+" ASC";
+
+        return select;
+    }    
+    
+    /**
+     * Creates statement to obtain a specific key
+     */
+    public String createKeySelectStatement(){
+        SSHKeyKeys x =  (SSHKeyKeys) keys;
+    	String select =  "SELECT * FROM " + getFQTablename() + " WHERE ";
+
+	select += x.pub_key() + " =?";
+        
+        return select;
+    }    
+    
+    /**
+     * Creates the select statement for this table based on user/label, which
+     * should be the composite primary key
+     */
+    @Override
+    public String createSelectStatement(){
+        SSHKeyKeys x =  (SSHKeyKeys) keys;
+    	String select =  "SELECT * FROM " + getFQTablename() + " WHERE ";
+
+	select += x.username() + " =? AND " + x.label() + " =? ";
+
+        return select;
+    }
+
+    /**
+     * Creates update statement for (username,label) pair
+     */
+    @Override
+    public String createUpdateStatement() {
+	SSHKeyKeys x =  (SSHKeyKeys) keys;
+
+        String update = "UPDATE " + getFQTablename() + " SET ";
+
+        boolean isFirst = true;
+        for (ColumnDescriptorEntry cde : getColumnDescriptor()) {
+	    String name = cde.getName();
+	    if (!name.equals(x.username()) && !name.equals(x.label())) {
+		update = update + (isFirst ? "" : ", ") + name + "=?";
+		if (isFirst) {
+		    isFirst = false;
+		}   
+            }        	
+        }
+
+        update += ", "+TIME_LABEL+"=CURRENT_TIMESTAMP";
+        
+        String where = " WHERE " + x.username() + " =? " +
+		       " AND " + x.label() + " =? ";
+        
+        return update + where;
+    }
+
+    /**
+     * Creates delete statement for (username,label) pair
+     */
+    public String createDeleteStatement() {
+	SSHKeyKeys x =  (SSHKeyKeys) keys;
+
+        String delete = "DELETE FROM " + getFQTablename() +
+			" WHERE " + x.username() + " =? " +
+		        " AND " + x.label() + " =? ";
+        
+        return delete;
+    }
+
+    @Override
+    public String createInsertStatement() {
+        String out = "INSERT INTO " + getFQTablename() + "(" + createRegisterStatement() + ", " + TIME_LABEL+ ") VALUES (" ;
+        String qmarks = "";
+        for (int i = 0; i < getColumnDescriptor().size(); i++) {
+            qmarks = qmarks + "?" + (i + 1 == getColumnDescriptor().size() ? "" : ", ");
+        }
+        qmarks += ",CURRENT_TIMESTAMP";
+        
+        out = out + qmarks + ")";
+        return out;
+    }
+    
+}

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
@@ -51,7 +51,7 @@ public class SSHKeyTable extends Table {
 
 	select += x.username() + " =?";
         
-	select += " ORDER BY "+x.label()+" ASC";
+	select += " ORDER BY "+x.import_time()+" DESC";
 
         return select;
     }    

--- a/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
+++ b/master-portal/master-portal-server/src/main/java/org/masterportal/oauth2/server/storage/sql/table/SSHKeyTable.java
@@ -61,7 +61,7 @@ public class SSHKeyTable extends Table {
 
 	select += x.userName() + " =?";
         
-	select += " ORDER BY "+x.importTime()+" DESC";
+	select += " ORDER BY "+x.label()+" ASC";
 
         return select;
     }    

--- a/master-portal/master-portal-server/src/main/webapp/WEB-INF/web.xml
+++ b/master-portal/master-portal-server/src/main/webapp/WEB-INF/web.xml
@@ -124,6 +124,24 @@
         <url-pattern>/userinfo</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <servlet-name>sshkey</servlet-name>
+        <servlet-class>edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet.MPOA2SSHKeyServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>sshkey</servlet-name>
+        <url-pattern>/sshkey</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>sshkeylisting</servlet-name>
+        <servlet-class>edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet.MPOA2SSHKeyListingServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>sshkeylisting</servlet-name>
+        <url-pattern>/sshkeylisting</url-pattern>
+    </servlet-mapping>
+
 
     <!--
       The next section should be uncommented if you are running this as a standalone service under Tomcat.

--- a/master-portal/master-portal-server/src/main/webapp/WEB-INF/web.xml
+++ b/master-portal/master-portal-server/src/main/webapp/WEB-INF/web.xml
@@ -126,7 +126,7 @@
 
     <servlet>
         <servlet-name>sshkey</servlet-name>
-        <servlet-class>edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet.MPOA2SSHKeyServlet</servlet-class>
+        <servlet-class>org.masterportal.oauth2.server.servlet.MPOA2SSHKeyServlet</servlet-class>
     </servlet>
     <servlet-mapping>
         <servlet-name>sshkey</servlet-name>
@@ -135,7 +135,7 @@
 
     <servlet>
         <servlet-name>sshkeylisting</servlet-name>
-        <servlet-class>edu.uiuc.ncsa.myproxy.oa4mp.oauth2.servlet.MPOA2SSHKeyListingServlet</servlet-class>
+        <servlet-class>org.masterportal.oauth2.server.servlet.MPOA2SSHKeyListingServlet</servlet-class>
     </servlet>
     <servlet-mapping>
         <servlet-name>sshkeylisting</servlet-name>


### PR DESCRIPTION
This pull request implements the upload API for SSH public keys, plus an extra endpoint to retrieve a list of username/pubkey pairs, which can subsequently be used for e.g. myproxy access.
An implementation of a client to this API is the [SSH-portal](https://github.com/rcauth-eu/aarc-ssh-portal), which, like the demo [VO-portal](https://github.com/rcauth-eu/aarc-vo-portal), can be deployed in the same Tomcat instance as a separate web application.